### PR TITLE
Fix incorrect rule AST creation due to a parser error (rule without SEQ/PAR)

### DIFF
--- a/src/various/GrammarParser.cpp
+++ b/src/various/GrammarParser.cpp
@@ -338,14 +338,16 @@ namespace yy {
         break;
 
       case 90: // BODY_ELEMENTS
-      case 144: // STATEMENTS
+      case 146: // STATEMENTS
         value.move< AstListNode* > (that.value);
         break;
 
       case 91: // BODY_ELEMENT
-      case 122: // RULE_SYNTAX
-      case 125: // STATEMENT
-      case 129: // IMPOSSIBLE_SYNTAX
+      case 122: // RULE_STMT
+      case 123: // RULE_SYNTAX
+      case 126: // SIMPLE_STMT
+      case 127: // STATEMENT
+      case 131: // IMPOSSIBLE_SYNTAX
         value.move< AstNode* > (that.value);
         break;
 
@@ -359,15 +361,15 @@ namespace yy {
         value.move< BaseFunctionAtom* > (that.value);
         break;
 
-      case 141: // CALL_SYNTAX
+      case 143: // CALL_SYNTAX
         value.move< CallNode* > (that.value);
         break;
 
-      case 134: // CASE_SYNTAX
+      case 136: // CASE_SYNTAX
         value.move< CaseNode* > (that.value);
         break;
 
-      case 128: // DIEDIE_SYNTAX
+      case 130: // DIEDIE_SYNTAX
         value.move< DiedieNode* > (that.value);
         break;
 
@@ -385,7 +387,7 @@ namespace yy {
         value.move< FLOATING_T > (that.value);
         break;
 
-      case 151: // FORALL_SYNTAX
+      case 153: // FORALL_SYNTAX
         value.move< ForallNode* > (that.value);
         break;
 
@@ -398,7 +400,7 @@ namespace yy {
         value.move< INTEGER_T > (that.value);
         break;
 
-      case 145: // IFTHENELSE
+      case 147: // IFTHENELSE
         value.move< IfThenElseNode* > (that.value);
         break;
 
@@ -410,20 +412,20 @@ namespace yy {
         value.move< IntegerAtom* > (that.value);
         break;
 
-      case 146: // LET_SYNTAX
+      case 148: // LET_SYNTAX
         value.move< LetNode* > (that.value);
         break;
 
-      case 150: // POP_SYNTAX
+      case 152: // POP_SYNTAX
         value.move< PopNode* > (that.value);
         break;
 
-      case 130: // DEBUG_SYNTAX
-      case 132: // PRINT_SYNTAX
+      case 132: // DEBUG_SYNTAX
+      case 134: // PRINT_SYNTAX
         value.move< PrintNode* > (that.value);
         break;
 
-      case 149: // PUSH_SYNTAX
+      case 151: // PUSH_SYNTAX
         value.move< PushNode* > (that.value);
         break;
 
@@ -436,15 +438,15 @@ namespace yy {
         value.move< Type* > (that.value);
         break;
 
-      case 126: // ASSERT_SYNTAX
-      case 127: // ASSURE_SYNTAX
-      case 142: // SEQ_SYNTAX
-      case 143: // PAR_SYNTAX
-      case 152: // ITERATE_SYNTAX
+      case 128: // ASSERT_SYNTAX
+      case 129: // ASSURE_SYNTAX
+      case 144: // SEQ_SYNTAX
+      case 145: // PAR_SYNTAX
+      case 154: // ITERATE_SYNTAX
         value.move< UnaryNode* > (that.value);
         break;
 
-      case 133: // UPDATE_SYNTAX
+      case 135: // UPDATE_SYNTAX
         value.move< UpdateNode* > (that.value);
         break;
 
@@ -452,11 +454,11 @@ namespace yy {
         value.move< rational_t > (that.value);
         break;
 
-      case 136: // CASE_LABEL
-      case 137: // CASE_LABEL_DEFAULT
-      case 138: // CASE_LABEL_NUMBER
-      case 139: // CASE_LABEL_IDENT
-      case 140: // CASE_LABEL_STRING
+      case 138: // CASE_LABEL
+      case 139: // CASE_LABEL_DEFAULT
+      case 140: // CASE_LABEL_NUMBER
+      case 141: // CASE_LABEL_IDENT
+      case 142: // CASE_LABEL_STRING
         value.move< std::pair<AtomNode*, AstNode*> > (that.value);
         break;
 
@@ -464,7 +466,7 @@ namespace yy {
         value.move< std::pair<ExpressionBase*, ExpressionBase*> > (that.value);
         break;
 
-      case 124: // DUMPSPEC
+      case 125: // DUMPSPEC
         value.move< std::pair<std::string, std::vector<std::string>> > (that.value);
         break;
 
@@ -478,7 +480,7 @@ namespace yy {
         value.move< std::string > (that.value);
         break;
 
-      case 131: // DEBUG_ATOM_LIST
+      case 133: // DEBUG_ATOM_LIST
         value.move< std::vector<ExpressionBase*> > (that.value);
         break;
 
@@ -495,7 +497,7 @@ namespace yy {
         value.move< std::vector<Type*> > (that.value);
         break;
 
-      case 135: // CASE_LABEL_LIST
+      case 137: // CASE_LABEL_LIST
         value.move< std::vector<std::pair<AtomNode*, AstNode*>> > (that.value);
         break;
 
@@ -504,7 +506,7 @@ namespace yy {
         value.move< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > (that.value);
         break;
 
-      case 123: // DUMPSPEC_LIST
+      case 124: // DUMPSPEC_LIST
         value.move< std::vector<std::pair<std::string, std::vector<std::string>>> > (that.value);
         break;
 
@@ -533,14 +535,16 @@ namespace yy {
         break;
 
       case 90: // BODY_ELEMENTS
-      case 144: // STATEMENTS
+      case 146: // STATEMENTS
         value.copy< AstListNode* > (that.value);
         break;
 
       case 91: // BODY_ELEMENT
-      case 122: // RULE_SYNTAX
-      case 125: // STATEMENT
-      case 129: // IMPOSSIBLE_SYNTAX
+      case 122: // RULE_STMT
+      case 123: // RULE_SYNTAX
+      case 126: // SIMPLE_STMT
+      case 127: // STATEMENT
+      case 131: // IMPOSSIBLE_SYNTAX
         value.copy< AstNode* > (that.value);
         break;
 
@@ -554,15 +558,15 @@ namespace yy {
         value.copy< BaseFunctionAtom* > (that.value);
         break;
 
-      case 141: // CALL_SYNTAX
+      case 143: // CALL_SYNTAX
         value.copy< CallNode* > (that.value);
         break;
 
-      case 134: // CASE_SYNTAX
+      case 136: // CASE_SYNTAX
         value.copy< CaseNode* > (that.value);
         break;
 
-      case 128: // DIEDIE_SYNTAX
+      case 130: // DIEDIE_SYNTAX
         value.copy< DiedieNode* > (that.value);
         break;
 
@@ -580,7 +584,7 @@ namespace yy {
         value.copy< FLOATING_T > (that.value);
         break;
 
-      case 151: // FORALL_SYNTAX
+      case 153: // FORALL_SYNTAX
         value.copy< ForallNode* > (that.value);
         break;
 
@@ -593,7 +597,7 @@ namespace yy {
         value.copy< INTEGER_T > (that.value);
         break;
 
-      case 145: // IFTHENELSE
+      case 147: // IFTHENELSE
         value.copy< IfThenElseNode* > (that.value);
         break;
 
@@ -605,20 +609,20 @@ namespace yy {
         value.copy< IntegerAtom* > (that.value);
         break;
 
-      case 146: // LET_SYNTAX
+      case 148: // LET_SYNTAX
         value.copy< LetNode* > (that.value);
         break;
 
-      case 150: // POP_SYNTAX
+      case 152: // POP_SYNTAX
         value.copy< PopNode* > (that.value);
         break;
 
-      case 130: // DEBUG_SYNTAX
-      case 132: // PRINT_SYNTAX
+      case 132: // DEBUG_SYNTAX
+      case 134: // PRINT_SYNTAX
         value.copy< PrintNode* > (that.value);
         break;
 
-      case 149: // PUSH_SYNTAX
+      case 151: // PUSH_SYNTAX
         value.copy< PushNode* > (that.value);
         break;
 
@@ -631,15 +635,15 @@ namespace yy {
         value.copy< Type* > (that.value);
         break;
 
-      case 126: // ASSERT_SYNTAX
-      case 127: // ASSURE_SYNTAX
-      case 142: // SEQ_SYNTAX
-      case 143: // PAR_SYNTAX
-      case 152: // ITERATE_SYNTAX
+      case 128: // ASSERT_SYNTAX
+      case 129: // ASSURE_SYNTAX
+      case 144: // SEQ_SYNTAX
+      case 145: // PAR_SYNTAX
+      case 154: // ITERATE_SYNTAX
         value.copy< UnaryNode* > (that.value);
         break;
 
-      case 133: // UPDATE_SYNTAX
+      case 135: // UPDATE_SYNTAX
         value.copy< UpdateNode* > (that.value);
         break;
 
@@ -647,11 +651,11 @@ namespace yy {
         value.copy< rational_t > (that.value);
         break;
 
-      case 136: // CASE_LABEL
-      case 137: // CASE_LABEL_DEFAULT
-      case 138: // CASE_LABEL_NUMBER
-      case 139: // CASE_LABEL_IDENT
-      case 140: // CASE_LABEL_STRING
+      case 138: // CASE_LABEL
+      case 139: // CASE_LABEL_DEFAULT
+      case 140: // CASE_LABEL_NUMBER
+      case 141: // CASE_LABEL_IDENT
+      case 142: // CASE_LABEL_STRING
         value.copy< std::pair<AtomNode*, AstNode*> > (that.value);
         break;
 
@@ -659,7 +663,7 @@ namespace yy {
         value.copy< std::pair<ExpressionBase*, ExpressionBase*> > (that.value);
         break;
 
-      case 124: // DUMPSPEC
+      case 125: // DUMPSPEC
         value.copy< std::pair<std::string, std::vector<std::string>> > (that.value);
         break;
 
@@ -673,7 +677,7 @@ namespace yy {
         value.copy< std::string > (that.value);
         break;
 
-      case 131: // DEBUG_ATOM_LIST
+      case 133: // DEBUG_ATOM_LIST
         value.copy< std::vector<ExpressionBase*> > (that.value);
         break;
 
@@ -690,7 +694,7 @@ namespace yy {
         value.copy< std::vector<Type*> > (that.value);
         break;
 
-      case 135: // CASE_LABEL_LIST
+      case 137: // CASE_LABEL_LIST
         value.copy< std::vector<std::pair<AtomNode*, AstNode*>> > (that.value);
         break;
 
@@ -699,7 +703,7 @@ namespace yy {
         value.copy< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > (that.value);
         break;
 
-      case 123: // DUMPSPEC_LIST
+      case 124: // DUMPSPEC_LIST
         value.copy< std::vector<std::pair<std::string, std::vector<std::string>>> > (that.value);
         break;
 
@@ -857,7 +861,7 @@ namespace yy {
   // @$.begin.filename = @$.end.filename = driver.get_filename_ptr();
 }
 
-#line 861 "GrammarParser.cpp" // lalr1.cc:741
+#line 865 "GrammarParser.cpp" // lalr1.cc:741
 
     /* Initialize the stack.  The initial state will be set in
        yynewstate, since the latter expects the semantical and the
@@ -952,14 +956,16 @@ namespace yy {
         break;
 
       case 90: // BODY_ELEMENTS
-      case 144: // STATEMENTS
+      case 146: // STATEMENTS
         yylhs.value.build< AstListNode* > ();
         break;
 
       case 91: // BODY_ELEMENT
-      case 122: // RULE_SYNTAX
-      case 125: // STATEMENT
-      case 129: // IMPOSSIBLE_SYNTAX
+      case 122: // RULE_STMT
+      case 123: // RULE_SYNTAX
+      case 126: // SIMPLE_STMT
+      case 127: // STATEMENT
+      case 131: // IMPOSSIBLE_SYNTAX
         yylhs.value.build< AstNode* > ();
         break;
 
@@ -973,15 +979,15 @@ namespace yy {
         yylhs.value.build< BaseFunctionAtom* > ();
         break;
 
-      case 141: // CALL_SYNTAX
+      case 143: // CALL_SYNTAX
         yylhs.value.build< CallNode* > ();
         break;
 
-      case 134: // CASE_SYNTAX
+      case 136: // CASE_SYNTAX
         yylhs.value.build< CaseNode* > ();
         break;
 
-      case 128: // DIEDIE_SYNTAX
+      case 130: // DIEDIE_SYNTAX
         yylhs.value.build< DiedieNode* > ();
         break;
 
@@ -999,7 +1005,7 @@ namespace yy {
         yylhs.value.build< FLOATING_T > ();
         break;
 
-      case 151: // FORALL_SYNTAX
+      case 153: // FORALL_SYNTAX
         yylhs.value.build< ForallNode* > ();
         break;
 
@@ -1012,7 +1018,7 @@ namespace yy {
         yylhs.value.build< INTEGER_T > ();
         break;
 
-      case 145: // IFTHENELSE
+      case 147: // IFTHENELSE
         yylhs.value.build< IfThenElseNode* > ();
         break;
 
@@ -1024,20 +1030,20 @@ namespace yy {
         yylhs.value.build< IntegerAtom* > ();
         break;
 
-      case 146: // LET_SYNTAX
+      case 148: // LET_SYNTAX
         yylhs.value.build< LetNode* > ();
         break;
 
-      case 150: // POP_SYNTAX
+      case 152: // POP_SYNTAX
         yylhs.value.build< PopNode* > ();
         break;
 
-      case 130: // DEBUG_SYNTAX
-      case 132: // PRINT_SYNTAX
+      case 132: // DEBUG_SYNTAX
+      case 134: // PRINT_SYNTAX
         yylhs.value.build< PrintNode* > ();
         break;
 
-      case 149: // PUSH_SYNTAX
+      case 151: // PUSH_SYNTAX
         yylhs.value.build< PushNode* > ();
         break;
 
@@ -1050,15 +1056,15 @@ namespace yy {
         yylhs.value.build< Type* > ();
         break;
 
-      case 126: // ASSERT_SYNTAX
-      case 127: // ASSURE_SYNTAX
-      case 142: // SEQ_SYNTAX
-      case 143: // PAR_SYNTAX
-      case 152: // ITERATE_SYNTAX
+      case 128: // ASSERT_SYNTAX
+      case 129: // ASSURE_SYNTAX
+      case 144: // SEQ_SYNTAX
+      case 145: // PAR_SYNTAX
+      case 154: // ITERATE_SYNTAX
         yylhs.value.build< UnaryNode* > ();
         break;
 
-      case 133: // UPDATE_SYNTAX
+      case 135: // UPDATE_SYNTAX
         yylhs.value.build< UpdateNode* > ();
         break;
 
@@ -1066,11 +1072,11 @@ namespace yy {
         yylhs.value.build< rational_t > ();
         break;
 
-      case 136: // CASE_LABEL
-      case 137: // CASE_LABEL_DEFAULT
-      case 138: // CASE_LABEL_NUMBER
-      case 139: // CASE_LABEL_IDENT
-      case 140: // CASE_LABEL_STRING
+      case 138: // CASE_LABEL
+      case 139: // CASE_LABEL_DEFAULT
+      case 140: // CASE_LABEL_NUMBER
+      case 141: // CASE_LABEL_IDENT
+      case 142: // CASE_LABEL_STRING
         yylhs.value.build< std::pair<AtomNode*, AstNode*> > ();
         break;
 
@@ -1078,7 +1084,7 @@ namespace yy {
         yylhs.value.build< std::pair<ExpressionBase*, ExpressionBase*> > ();
         break;
 
-      case 124: // DUMPSPEC
+      case 125: // DUMPSPEC
         yylhs.value.build< std::pair<std::string, std::vector<std::string>> > ();
         break;
 
@@ -1092,7 +1098,7 @@ namespace yy {
         yylhs.value.build< std::string > ();
         break;
 
-      case 131: // DEBUG_ATOM_LIST
+      case 133: // DEBUG_ATOM_LIST
         yylhs.value.build< std::vector<ExpressionBase*> > ();
         break;
 
@@ -1109,7 +1115,7 @@ namespace yy {
         yylhs.value.build< std::vector<Type*> > ();
         break;
 
-      case 135: // CASE_LABEL_LIST
+      case 137: // CASE_LABEL_LIST
         yylhs.value.build< std::vector<std::pair<AtomNode*, AstNode*>> > ();
         break;
 
@@ -1118,7 +1124,7 @@ namespace yy {
         yylhs.value.build< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > ();
         break;
 
-      case 123: // DUMPSPEC_LIST
+      case 124: // DUMPSPEC_LIST
         yylhs.value.build< std::vector<std::pair<std::string, std::vector<std::string>>> > ();
         break;
 
@@ -1149,7 +1155,7 @@ namespace yy {
     {
     driver.result = new Ast( yylhs.location, yystack_[1].value.as< SpecificationNode* > (), yystack_[0].value.as< AstListNode* > () );
 }
-#line 1153 "GrammarParser.cpp" // lalr1.cc:859
+#line 1159 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 3:
@@ -1157,7 +1163,7 @@ namespace yy {
     {
     yylhs.value.as< SpecificationNode* > () = new SpecificationNode( yylhs.location, yystack_[0].value.as< std::string > () );
 }
-#line 1161 "GrammarParser.cpp" // lalr1.cc:859
+#line 1167 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 4:
@@ -1166,7 +1172,7 @@ namespace yy {
     yystack_[1].value.as< AstListNode* > ()->add(yystack_[0].value.as< AstNode* > ());
     yylhs.value.as< AstListNode* > () = yystack_[1].value.as< AstListNode* > ();
 }
-#line 1170 "GrammarParser.cpp" // lalr1.cc:859
+#line 1176 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 5:
@@ -1175,25 +1181,25 @@ namespace yy {
     yylhs.value.as< AstListNode* > () = new AstListNode(yylhs.location, NodeType::BODY_ELEMENTS);
     yylhs.value.as< AstListNode* > ()->add(yystack_[0].value.as< AstNode* > ());
 }
-#line 1179 "GrammarParser.cpp" // lalr1.cc:859
+#line 1185 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 6:
 #line 273 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AstNode* > () = new AstNode(NodeType::PROVIDER); }
-#line 1185 "GrammarParser.cpp" // lalr1.cc:859
+#line 1191 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 7:
 #line 274 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AstNode* > () = new AstNode(NodeType::OPTION); }
-#line 1191 "GrammarParser.cpp" // lalr1.cc:859
+#line 1197 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 8:
 #line 275 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AstNode* > () = new EnumDefNode(yylhs.location, yystack_[0].value.as< Enum* > ()); }
-#line 1197 "GrammarParser.cpp" // lalr1.cc:859
+#line 1203 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 9:
@@ -1212,7 +1218,7 @@ namespace yy {
                     delete yystack_[0].value.as< Function* > ();
                 }
             }
-#line 1216 "GrammarParser.cpp" // lalr1.cc:859
+#line 1222 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 10:
@@ -1230,13 +1236,13 @@ namespace yy {
                     delete yystack_[0].value.as< Function* > ();
                 }
             }
-#line 1234 "GrammarParser.cpp" // lalr1.cc:859
+#line 1240 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 11:
 #line 303 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AstNode* > () = yystack_[0].value.as< InitNode* > (); }
-#line 1240 "GrammarParser.cpp" // lalr1.cc:859
+#line 1246 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 12:
@@ -1252,7 +1258,7 @@ namespace yy {
                     // the AST, so it will be deleted later
                 }
            }
-#line 1256 "GrammarParser.cpp" // lalr1.cc:859
+#line 1262 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 13:
@@ -1260,7 +1266,7 @@ namespace yy {
     {
     yylhs.value.as< InitNode* > () = new InitNode( yylhs.location, yystack_[0].value.as< std::string > () );
 }
-#line 1264 "GrammarParser.cpp" // lalr1.cc:859
+#line 1270 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 16:
@@ -1284,7 +1290,7 @@ namespace yy {
                     }
                 }
            }
-#line 1288 "GrammarParser.cpp" // lalr1.cc:859
+#line 1294 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 17:
@@ -1293,7 +1299,7 @@ namespace yy {
                   // TODO: 2nd argument should be a reference
                   yylhs.value.as< Function* > () = new Function(yystack_[5].value.as< std::string > (), yylhs.location, yystack_[3].value.as< std::vector<Type*> > (), yystack_[0].value.as< ExpressionBase* > (), new Type(TypeType::UNKNOWN));
                 }
-#line 1297 "GrammarParser.cpp" // lalr1.cc:859
+#line 1303 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 18:
@@ -1301,7 +1307,7 @@ namespace yy {
     {
                   yylhs.value.as< Function* > () = new Function(yystack_[2].value.as< std::string > (), yylhs.location, yystack_[0].value.as< ExpressionBase* > (), new Type(TypeType::UNKNOWN));
                 }
-#line 1305 "GrammarParser.cpp" // lalr1.cc:859
+#line 1311 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 19:
@@ -1309,7 +1315,7 @@ namespace yy {
     {
                   yylhs.value.as< Function* > () = new Function(yystack_[4].value.as< std::string > (), yylhs.location, yystack_[0].value.as< ExpressionBase* > (), new Type(TypeType::UNKNOWN));
                 }
-#line 1313 "GrammarParser.cpp" // lalr1.cc:859
+#line 1319 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 20:
@@ -1317,7 +1323,7 @@ namespace yy {
     {
                   yylhs.value.as< Function* > () = new Function(yystack_[7].value.as< std::string > (), yylhs.location, yystack_[5].value.as< std::vector<Type*> > (), yystack_[0].value.as< ExpressionBase* > (), yystack_[2].value.as< Type* > ());
                 }
-#line 1321 "GrammarParser.cpp" // lalr1.cc:859
+#line 1327 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 21:
@@ -1325,7 +1331,7 @@ namespace yy {
     {
                   yylhs.value.as< Function* > () = new Function(yystack_[4].value.as< std::string > (), yylhs.location, yystack_[0].value.as< ExpressionBase* > (), yystack_[2].value.as< Type* > ());
                 }
-#line 1329 "GrammarParser.cpp" // lalr1.cc:859
+#line 1335 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 22:
@@ -1333,7 +1339,7 @@ namespace yy {
     {
                   yylhs.value.as< Function* > () = new Function(yystack_[6].value.as< std::string > (), yylhs.location, yystack_[0].value.as< ExpressionBase* > (), yystack_[2].value.as< Type* > ());
                 }
-#line 1337 "GrammarParser.cpp" // lalr1.cc:859
+#line 1343 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 23:
@@ -1342,7 +1348,7 @@ namespace yy {
                       auto attrs = parse_function_attributes(driver, yylhs.location, yystack_[4].value.as< std::vector<std::string> > ());
                       yylhs.value.as< Function* > () = new Function(attrs.first, attrs.second, yystack_[2].value.as< std::string > (), yylhs.location, yystack_[1].value.as< std::pair<std::vector<Type*>, Type*> > ().first, yystack_[1].value.as< std::pair<std::vector<Type*>, Type*> > ().second, yystack_[0].value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > ());
                    }
-#line 1346 "GrammarParser.cpp" // lalr1.cc:859
+#line 1352 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 24:
@@ -1351,7 +1357,7 @@ namespace yy {
                       auto attrs = parse_function_attributes(driver, yylhs.location, yystack_[3].value.as< std::vector<std::string> > ());
                       yylhs.value.as< Function* > () = new Function(attrs.first, attrs.second, yystack_[1].value.as< std::string > (), yylhs.location, yystack_[0].value.as< std::pair<std::vector<Type*>, Type*> > ().first, yystack_[0].value.as< std::pair<std::vector<Type*>, Type*> > ().second, nullptr);
                    }
-#line 1355 "GrammarParser.cpp" // lalr1.cc:859
+#line 1361 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 25:
@@ -1359,25 +1365,25 @@ namespace yy {
     {
                       yylhs.value.as< Function* > () = new Function(yystack_[2].value.as< std::string > (), yylhs.location, yystack_[1].value.as< std::pair<std::vector<Type*>, Type*> > ().first, yystack_[1].value.as< std::pair<std::vector<Type*>, Type*> > ().second, yystack_[0].value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > ());
                    }
-#line 1363 "GrammarParser.cpp" // lalr1.cc:859
+#line 1369 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 26:
 #line 387 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< Function* > () = new Function(yystack_[1].value.as< std::string > (), yylhs.location, yystack_[0].value.as< std::pair<std::vector<Type*>, Type*> > ().first, yystack_[0].value.as< std::pair<std::vector<Type*>, Type*> > ().second, nullptr); }
-#line 1369 "GrammarParser.cpp" // lalr1.cc:859
+#line 1375 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 27:
 #line 390 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = std::move(yystack_[1].value.as< std::vector<std::string> > ()); }
-#line 1375 "GrammarParser.cpp" // lalr1.cc:859
+#line 1381 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 28:
 #line 391 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::string> > () = std::move(yystack_[0].value.as< std::vector<std::string> > ()); }
-#line 1381 "GrammarParser.cpp" // lalr1.cc:859
+#line 1387 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 29:
@@ -1386,7 +1392,7 @@ namespace yy {
                             yylhs.value.as< std::vector<std::string> > () = std::move(yystack_[2].value.as< std::vector<std::string> > ());
                             yylhs.value.as< std::vector<std::string> > ().push_back(yystack_[0].value.as< std::string > ());
                         }
-#line 1390 "GrammarParser.cpp" // lalr1.cc:859
+#line 1396 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 30:
@@ -1395,7 +1401,7 @@ namespace yy {
                             yylhs.value.as< std::vector<std::string> > () = std::vector<std::string>();
                             yylhs.value.as< std::vector<std::string> > ().push_back(yystack_[0].value.as< std::string > ());
                         }
-#line 1399 "GrammarParser.cpp" // lalr1.cc:859
+#line 1405 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 31:
@@ -1405,13 +1411,13 @@ namespace yy {
                     std::vector<Type*> foo;
                     yylhs.value.as< std::pair<std::vector<Type*>, Type*> > () = std::pair<std::vector<Type*>, Type*>(foo, yystack_[0].value.as< Type* > ());
                   }
-#line 1409 "GrammarParser.cpp" // lalr1.cc:859
+#line 1415 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 32:
 #line 410 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::pair<std::vector<Type*>, Type*> > () = std::pair<std::vector<Type*>, Type*>(yystack_[2].value.as< std::vector<Type*> > (), yystack_[0].value.as< Type* > ()); }
-#line 1415 "GrammarParser.cpp" // lalr1.cc:859
+#line 1421 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 33:
@@ -1421,7 +1427,7 @@ namespace yy {
         driver.binding_offsets[yystack_[2].value.as< std::string > ()] = size;
         yylhs.value.as< Type* > () = yystack_[0].value.as< Type* > ();
      }
-#line 1425 "GrammarParser.cpp" // lalr1.cc:859
+#line 1431 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 34:
@@ -1432,19 +1438,19 @@ namespace yy {
         // TODO: fail for rules without types and print warnings
         yylhs.value.as< Type* > () = new Type(TypeType::INTEGER);
      }
-#line 1436 "GrammarParser.cpp" // lalr1.cc:859
+#line 1442 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 35:
 #line 427 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<Type*> > () = std::move(yystack_[0].value.as< std::vector<Type*> > ()); }
-#line 1442 "GrammarParser.cpp" // lalr1.cc:859
+#line 1448 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 36:
 #line 428 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<Type*> > () = std::move(yystack_[1].value.as< std::vector<Type*> > ()); }
-#line 1448 "GrammarParser.cpp" // lalr1.cc:859
+#line 1454 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 37:
@@ -1453,13 +1459,13 @@ namespace yy {
                         yylhs.value.as< std::vector<Type*> > () = std::move(yystack_[2].value.as< std::vector<Type*> > ());
                         yylhs.value.as< std::vector<Type*> > ().push_back(yystack_[0].value.as< Type* > ());
                    }
-#line 1457 "GrammarParser.cpp" // lalr1.cc:859
+#line 1463 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 38:
 #line 434 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<Type*> > ().push_back(yystack_[0].value.as< Type* > ()); }
-#line 1463 "GrammarParser.cpp" // lalr1.cc:859
+#line 1469 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 39:
@@ -1468,7 +1474,7 @@ namespace yy {
                             yystack_[0].value.as< std::vector<Type*> > ().insert(yystack_[0].value.as< std::vector<Type*> > ().begin(), yystack_[2].value.as< Type* > ());
                             yylhs.value.as< std::vector<Type*> > () = std::move(yystack_[0].value.as< std::vector<Type*> > ());
                         }
-#line 1472 "GrammarParser.cpp" // lalr1.cc:859
+#line 1478 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 40:
@@ -1477,7 +1483,7 @@ namespace yy {
                           // TODO: limit memory size
                             yylhs.value.as< std::vector<Type*> > ().push_back(yystack_[1].value.as< Type* > ());
                         }
-#line 1481 "GrammarParser.cpp" // lalr1.cc:859
+#line 1487 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 41:
@@ -1485,13 +1491,13 @@ namespace yy {
     {
                             yylhs.value.as< std::vector<Type*> > ().push_back(yystack_[0].value.as< Type* > ());
                         }
-#line 1489 "GrammarParser.cpp" // lalr1.cc:859
+#line 1495 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 42:
 #line 451 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< Type* > () = new Type(yystack_[0].value.as< std::string > ()); /* TODO check invalid types */}
-#line 1495 "GrammarParser.cpp" // lalr1.cc:859
+#line 1501 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 43:
@@ -1499,7 +1505,7 @@ namespace yy {
     {
                yylhs.value.as< Type* > () = new Type(yystack_[3].value.as< std::string > (), yystack_[1].value.as< std::vector<Type*> > ());
            }
-#line 1503 "GrammarParser.cpp" // lalr1.cc:859
+#line 1509 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 44:
@@ -1512,7 +1518,7 @@ namespace yy {
                    driver.error(yylhs.location, "start of subrange must be smaller than the end");
                }
            }
-#line 1516 "GrammarParser.cpp" // lalr1.cc:859
+#line 1522 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 45:
@@ -1525,7 +1531,7 @@ namespace yy {
                    driver.error(yylhs.location, "invalid size for Bit type");
                }
            }
-#line 1529 "GrammarParser.cpp" // lalr1.cc:859
+#line 1535 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 46:
@@ -1534,43 +1540,43 @@ namespace yy {
                       yystack_[0].value.as< std::vector<Type*> > ().push_back(yystack_[2].value.as< Type* > ());
                       yylhs.value.as< std::vector<Type*> > () = std::move(yystack_[0].value.as< std::vector<Type*> > ());
                     }
-#line 1538 "GrammarParser.cpp" // lalr1.cc:859
+#line 1544 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 47:
 #line 479 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<Type*> > ().push_back(yystack_[1].value.as< Type* > ()); }
-#line 1544 "GrammarParser.cpp" // lalr1.cc:859
+#line 1550 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 48:
 #line 480 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<Type*> > ().push_back(yystack_[0].value.as< Type* > ()); }
-#line 1550 "GrammarParser.cpp" // lalr1.cc:859
+#line 1556 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 49:
 #line 483 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > () = yystack_[1].value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > (); }
-#line 1556 "GrammarParser.cpp" // lalr1.cc:859
+#line 1562 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 50:
 #line 484 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > () = nullptr; }
-#line 1562 "GrammarParser.cpp" // lalr1.cc:859
+#line 1568 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 51:
 #line 487 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > () = yystack_[2].value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > (); yystack_[2].value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > ()->push_back(yystack_[0].value.as< std::pair<ExpressionBase*, ExpressionBase*> > ()); }
-#line 1568 "GrammarParser.cpp" // lalr1.cc:859
+#line 1574 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 52:
 #line 488 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > () = yystack_[1].value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > (); }
-#line 1574 "GrammarParser.cpp" // lalr1.cc:859
+#line 1580 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 53:
@@ -1579,145 +1585,145 @@ namespace yy {
                     yylhs.value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > () = new std::vector<std::pair<ExpressionBase*, ExpressionBase*>>();
                     yylhs.value.as< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > ()->push_back(yystack_[0].value.as< std::pair<ExpressionBase*, ExpressionBase*> > ());
                 }
-#line 1583 "GrammarParser.cpp" // lalr1.cc:859
+#line 1589 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 54:
 #line 496 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::pair<ExpressionBase*, ExpressionBase*> > () = std::pair<ExpressionBase*, ExpressionBase*>(nullptr, yystack_[0].value.as< ExpressionBase* > ()); }
-#line 1589 "GrammarParser.cpp" // lalr1.cc:859
+#line 1595 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 55:
 #line 497 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::pair<ExpressionBase*, ExpressionBase*> > () = std::pair<ExpressionBase*, ExpressionBase*>(yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > ()); }
-#line 1595 "GrammarParser.cpp" // lalr1.cc:859
+#line 1601 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 56:
 #line 500 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = yystack_[0].value.as< BaseFunctionAtom* > (); }
-#line 1601 "GrammarParser.cpp" // lalr1.cc:859
+#line 1607 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 57:
 #line 501 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = yystack_[0].value.as< AtomNode* > (); }
-#line 1607 "GrammarParser.cpp" // lalr1.cc:859
+#line 1613 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 58:
 #line 502 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = yystack_[0].value.as< ExpressionBase* > (); }
-#line 1613 "GrammarParser.cpp" // lalr1.cc:859
+#line 1619 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 59:
 #line 505 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new RuleAtom(yylhs.location, std::move(yystack_[0].value.as< std::string > ())); }
-#line 1619 "GrammarParser.cpp" // lalr1.cc:859
+#line 1625 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 60:
 #line 506 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = yystack_[0].value.as< AtomNode* > (); }
-#line 1625 "GrammarParser.cpp" // lalr1.cc:859
+#line 1631 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 61:
 #line 507 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new StringAtom(yylhs.location, std::move(yystack_[0].value.as< std::string > ())); }
-#line 1631 "GrammarParser.cpp" // lalr1.cc:859
+#line 1637 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 62:
 #line 508 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new ListAtom(yylhs.location, yystack_[0].value.as< std::vector<ExpressionBase*>* > ()); }
-#line 1637 "GrammarParser.cpp" // lalr1.cc:859
+#line 1643 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 63:
 #line 509 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = yystack_[0].value.as< AtomNode* > (); }
-#line 1643 "GrammarParser.cpp" // lalr1.cc:859
+#line 1649 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 64:
 #line 510 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new IntegerAtom(yylhs.location, 0); }
-#line 1649 "GrammarParser.cpp" // lalr1.cc:859
+#line 1655 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 65:
 #line 511 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new SelfAtom(yylhs.location); }
-#line 1655 "GrammarParser.cpp" // lalr1.cc:859
+#line 1661 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 66:
 #line 512 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new UndefAtom(yylhs.location); }
-#line 1661 "GrammarParser.cpp" // lalr1.cc:859
+#line 1667 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 67:
 #line 513 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new BooleanAtom(yylhs.location, true); }
-#line 1667 "GrammarParser.cpp" // lalr1.cc:859
+#line 1673 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 68:
 #line 514 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new BooleanAtom(yylhs.location, false); }
-#line 1673 "GrammarParser.cpp" // lalr1.cc:859
+#line 1679 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 69:
 #line 517 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< IntegerAtom* > () = new IntegerAtom(yylhs.location, yystack_[0].value.as< INTEGER_T > ()); }
-#line 1679 "GrammarParser.cpp" // lalr1.cc:859
+#line 1685 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 70:
 #line 518 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< IntegerAtom* > () = new IntegerAtom(yylhs.location, (-1) * yystack_[0].value.as< INTEGER_T > ()); }
-#line 1685 "GrammarParser.cpp" // lalr1.cc:859
+#line 1691 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 71:
 #line 519 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< IntegerAtom* > () = new IntegerAtom(yylhs.location, yystack_[0].value.as< INTEGER_T > ()); }
-#line 1691 "GrammarParser.cpp" // lalr1.cc:859
+#line 1697 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 72:
 #line 520 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = yystack_[0].value.as< IntegerAtom* > (); }
-#line 1697 "GrammarParser.cpp" // lalr1.cc:859
+#line 1703 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 73:
 #line 521 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new FloatingAtom(yylhs.location, yystack_[0].value.as< FLOATING_T > ()); }
-#line 1703 "GrammarParser.cpp" // lalr1.cc:859
+#line 1709 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 74:
 #line 522 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new FloatingAtom(yylhs.location, (-1) * yystack_[0].value.as< FLOATING_T > ()); }
-#line 1709 "GrammarParser.cpp" // lalr1.cc:859
+#line 1715 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 75:
 #line 523 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new FloatingAtom(yylhs.location, yystack_[0].value.as< FLOATING_T > ()); }
-#line 1715 "GrammarParser.cpp" // lalr1.cc:859
+#line 1721 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 76:
 #line 524 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new RationalAtom(yylhs.location, yystack_[0].value.as< rational_t > ()); }
-#line 1721 "GrammarParser.cpp" // lalr1.cc:859
+#line 1727 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 77:
@@ -1726,19 +1732,19 @@ namespace yy {
           yystack_[0].value.as< rational_t > ().numerator *= -1;
           yylhs.value.as< AtomNode* > () = new RationalAtom(yylhs.location, yystack_[0].value.as< rational_t > ());
         }
-#line 1730 "GrammarParser.cpp" // lalr1.cc:859
+#line 1736 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 78:
 #line 529 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< AtomNode* > () = new RationalAtom(yylhs.location, yystack_[0].value.as< rational_t > ()); }
-#line 1736 "GrammarParser.cpp" // lalr1.cc:859
+#line 1742 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 79:
 #line 532 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::string > () = yystack_[0].value.as< std::string > (); }
-#line 1742 "GrammarParser.cpp" // lalr1.cc:859
+#line 1748 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 80:
@@ -1751,31 +1757,31 @@ namespace yy {
                 yylhs.value.as< AtomNode* > () = nullptr;
               }
             }
-#line 1755 "GrammarParser.cpp" // lalr1.cc:859
+#line 1761 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 81:
 #line 546 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<ExpressionBase*>* > () = yystack_[1].value.as< std::vector<ExpressionBase*>* > (); }
-#line 1761 "GrammarParser.cpp" // lalr1.cc:859
+#line 1767 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 82:
 #line 547 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<ExpressionBase*>* > () = new std::vector<ExpressionBase*>(); }
-#line 1767 "GrammarParser.cpp" // lalr1.cc:859
+#line 1773 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 83:
 #line 551 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<ExpressionBase*>* > () = yystack_[0].value.as< std::vector<ExpressionBase*>* > (); }
-#line 1773 "GrammarParser.cpp" // lalr1.cc:859
+#line 1779 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 84:
 #line 552 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<ExpressionBase*>* > () = yystack_[1].value.as< std::vector<ExpressionBase*>* > (); }
-#line 1779 "GrammarParser.cpp" // lalr1.cc:859
+#line 1785 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 85:
@@ -1784,7 +1790,7 @@ namespace yy {
                           yylhs.value.as< std::vector<ExpressionBase*>* > () = yystack_[2].value.as< std::vector<ExpressionBase*>* > ();
                           yylhs.value.as< std::vector<ExpressionBase*>* > ()->push_back(yystack_[0].value.as< ExpressionBase* > ());
                         }
-#line 1788 "GrammarParser.cpp" // lalr1.cc:859
+#line 1794 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 86:
@@ -1793,127 +1799,127 @@ namespace yy {
                           yylhs.value.as< std::vector<ExpressionBase*>* > () = new std::vector<ExpressionBase*>;
                           yylhs.value.as< std::vector<ExpressionBase*>* > ()->push_back(yystack_[0].value.as< ExpressionBase* > ());
                         }
-#line 1797 "GrammarParser.cpp" // lalr1.cc:859
+#line 1803 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 87:
 #line 566 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::ADD); }
-#line 1803 "GrammarParser.cpp" // lalr1.cc:859
+#line 1809 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 88:
 #line 568 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::SUB); }
-#line 1809 "GrammarParser.cpp" // lalr1.cc:859
+#line 1815 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 89:
 #line 570 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::MUL); }
-#line 1815 "GrammarParser.cpp" // lalr1.cc:859
+#line 1821 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 90:
 #line 572 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::DIV); }
-#line 1821 "GrammarParser.cpp" // lalr1.cc:859
+#line 1827 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 91:
 #line 574 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::MOD); }
-#line 1827 "GrammarParser.cpp" // lalr1.cc:859
+#line 1833 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 92:
 #line 576 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::RAT_DIV); }
-#line 1833 "GrammarParser.cpp" // lalr1.cc:859
+#line 1839 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 93:
 #line 578 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::NEQ); }
-#line 1839 "GrammarParser.cpp" // lalr1.cc:859
+#line 1845 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 94:
 #line 580 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::EQ); }
-#line 1845 "GrammarParser.cpp" // lalr1.cc:859
+#line 1851 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 95:
 #line 582 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::LESSER); }
-#line 1851 "GrammarParser.cpp" // lalr1.cc:859
+#line 1857 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 96:
 #line 584 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::GREATER); }
-#line 1857 "GrammarParser.cpp" // lalr1.cc:859
+#line 1863 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 97:
 #line 586 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::LESSEREQ); }
-#line 1863 "GrammarParser.cpp" // lalr1.cc:859
+#line 1869 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 98:
 #line 588 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::GREATEREQ); }
-#line 1869 "GrammarParser.cpp" // lalr1.cc:859
+#line 1875 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 99:
 #line 590 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::OR); }
-#line 1875 "GrammarParser.cpp" // lalr1.cc:859
+#line 1881 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 100:
 #line 592 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::XOR); }
-#line 1881 "GrammarParser.cpp" // lalr1.cc:859
+#line 1887 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 101:
 #line 594 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< ExpressionBase* > (), ExpressionOperation::AND); }
-#line 1887 "GrammarParser.cpp" // lalr1.cc:859
+#line 1893 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 102:
 #line 596 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = new Expression(yylhs.location, yystack_[0].value.as< ExpressionBase* > (), nullptr, ExpressionOperation::NOT);}
-#line 1893 "GrammarParser.cpp" // lalr1.cc:859
+#line 1899 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 103:
 #line 597 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = yystack_[0].value.as< ExpressionBase* > (); }
-#line 1899 "GrammarParser.cpp" // lalr1.cc:859
+#line 1905 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 104:
 #line 600 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< ExpressionBase* > () = yystack_[1].value.as< ExpressionBase* > (); }
-#line 1905 "GrammarParser.cpp" // lalr1.cc:859
+#line 1911 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 105:
 #line 603 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< BaseFunctionAtom* > () = new FunctionAtom(yylhs.location, yystack_[0].value.as< std::string > ()); }
-#line 1911 "GrammarParser.cpp" // lalr1.cc:859
+#line 1917 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 106:
 #line 604 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< BaseFunctionAtom* > () = new FunctionAtom(yylhs.location, yystack_[2].value.as< std::string > ()); }
-#line 1917 "GrammarParser.cpp" // lalr1.cc:859
+#line 1923 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 107:
@@ -1928,263 +1934,291 @@ namespace yy {
                        yylhs.value.as< BaseFunctionAtom* > () = new FunctionAtom(yylhs.location, yystack_[3].value.as< std::string > (), yystack_[1].value.as< std::vector<ExpressionBase*>* > ());
                    }
                }
-#line 1932 "GrammarParser.cpp" // lalr1.cc:859
+#line 1938 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 108:
 #line 618 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = new RuleNode(yylhs.location, yystack_[0].value.as< AstNode* > (), yystack_[2].value.as< std::string > ()); }
-#line 1938 "GrammarParser.cpp" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
+#line 1944 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 109:
 #line 619 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                yylhs.value.as< AstNode* > () = new RuleNode(yylhs.location, yystack_[0].value.as< AstNode* > (), yystack_[4].value.as< std::string > ());
-           }
-#line 1946 "GrammarParser.cpp" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
+#line 1950 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 110:
-#line 622 "../../src/GrammarParser.yy" // lalr1.cc:859
+#line 620 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
-                yylhs.value.as< AstNode* > () = new RuleNode(yylhs.location, yystack_[0].value.as< AstNode* > (), yystack_[5].value.as< std::string > (), yystack_[3].value.as< std::vector<Type*> > ());
-           }
-#line 1954 "GrammarParser.cpp" // lalr1.cc:859
+              auto stmts = new AstListNode(yylhs.location, NodeType::STATEMENTS);
+              stmts->add(yystack_[0].value.as< AstNode* > ());
+              yylhs.value.as< AstNode* > () = new UnaryNode(yylhs.location, NodeType::PARBLOCK, stmts);
+          }
+#line 1960 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 111:
-#line 626 "../../src/GrammarParser.yy" // lalr1.cc:859
+#line 627 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = new RuleNode(yylhs.location, yystack_[0].value.as< AstNode* > (), yystack_[2].value.as< std::string > ()); }
+#line 1966 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
+  case 112:
+#line 628 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+                yylhs.value.as< AstNode* > () = new RuleNode(yylhs.location, yystack_[0].value.as< AstNode* > (), yystack_[4].value.as< std::string > ());
+           }
+#line 1974 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
+  case 113:
+#line 631 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+                yylhs.value.as< AstNode* > () = new RuleNode(yylhs.location, yystack_[0].value.as< AstNode* > (), yystack_[5].value.as< std::string > (), yystack_[3].value.as< std::vector<Type*> > ());
+           }
+#line 1982 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
+  case 114:
+#line 635 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
                 std::vector<Type*> tmp;
                 yylhs.value.as< AstNode* > () = new RuleNode(yylhs.location, yystack_[0].value.as< AstNode* > (), yystack_[4].value.as< std::string > (), tmp, yystack_[2].value.as< std::vector<std::pair<std::string, std::vector<std::string>>> > ());
            }
-#line 1963 "GrammarParser.cpp" // lalr1.cc:859
+#line 1991 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
-  case 112:
-#line 630 "../../src/GrammarParser.yy" // lalr1.cc:859
+  case 115:
+#line 639 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
                 std::vector<Type*> tmp;
                 yylhs.value.as< AstNode* > () = new RuleNode(yylhs.location, yystack_[0].value.as< AstNode* > (), yystack_[6].value.as< std::string > (), tmp, yystack_[2].value.as< std::vector<std::pair<std::string, std::vector<std::string>>> > ());
            }
-#line 1972 "GrammarParser.cpp" // lalr1.cc:859
+#line 2000 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
-  case 113:
-#line 634 "../../src/GrammarParser.yy" // lalr1.cc:859
+  case 116:
+#line 643 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
                 std::vector<Type*> tmp;
                 yylhs.value.as< AstNode* > () = new RuleNode(yylhs.location, yystack_[0].value.as< AstNode* > (), yystack_[7].value.as< std::string > (), tmp, yystack_[2].value.as< std::vector<std::pair<std::string, std::vector<std::string>>> > ());
            }
-#line 1981 "GrammarParser.cpp" // lalr1.cc:859
+#line 2009 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
-  case 114:
-#line 640 "../../src/GrammarParser.yy" // lalr1.cc:859
+  case 117:
+#line 649 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< std::vector<std::pair<std::string, std::vector<std::string>>> > () = std::move(yystack_[2].value.as< std::vector<std::pair<std::string, std::vector<std::string>>> > ()); yylhs.value.as< std::vector<std::pair<std::string, std::vector<std::string>>> > ().push_back(yystack_[0].value.as< std::pair<std::string, std::vector<std::string>> > ()); }
-#line 1987 "GrammarParser.cpp" // lalr1.cc:859
+#line 2015 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
-  case 115:
-#line 641 "../../src/GrammarParser.yy" // lalr1.cc:859
+  case 118:
+#line 650 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
                 yylhs.value.as< std::vector<std::pair<std::string, std::vector<std::string>>> > () = std::vector<std::pair<std::string,std::vector<std::string>>>();
                 yylhs.value.as< std::vector<std::pair<std::string, std::vector<std::string>>> > ().push_back(std::move(yystack_[0].value.as< std::pair<std::string, std::vector<std::string>> > ()));
              }
-#line 1996 "GrammarParser.cpp" // lalr1.cc:859
-    break;
-
-  case 116:
-#line 647 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-            yylhs.value.as< std::pair<std::string, std::vector<std::string>> > () = std::pair<std::string, std::vector<std::string>>(yystack_[0].value.as< std::string > (), yystack_[3].value.as< std::vector<std::string> > ());
-        }
-#line 2004 "GrammarParser.cpp" // lalr1.cc:859
-    break;
-
-  case 117:
-#line 652 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
-#line 2010 "GrammarParser.cpp" // lalr1.cc:859
-    break;
-
-  case 118:
-#line 653 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
-#line 2016 "GrammarParser.cpp" // lalr1.cc:859
+#line 2024 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 119:
-#line 654 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< DiedieNode* > (); }
-#line 2022 "GrammarParser.cpp" // lalr1.cc:859
+#line 656 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+            yylhs.value.as< std::pair<std::string, std::vector<std::string>> > () = std::pair<std::string, std::vector<std::string>>(yystack_[0].value.as< std::string > (), yystack_[3].value.as< std::vector<std::string> > ());
+        }
+#line 2032 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 120:
-#line 655 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< AstNode* > (); }
-#line 2028 "GrammarParser.cpp" // lalr1.cc:859
+#line 661 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
+#line 2038 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 121:
-#line 656 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< PrintNode* > (); }
-#line 2034 "GrammarParser.cpp" // lalr1.cc:859
+#line 662 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
+#line 2044 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 122:
-#line 657 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< PrintNode* > (); }
-#line 2040 "GrammarParser.cpp" // lalr1.cc:859
+#line 663 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< DiedieNode* > (); }
+#line 2050 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 123:
-#line 658 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UpdateNode* > (); }
-#line 2046 "GrammarParser.cpp" // lalr1.cc:859
+#line 664 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< AstNode* > (); }
+#line 2056 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 124:
-#line 659 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< CaseNode* > (); }
-#line 2052 "GrammarParser.cpp" // lalr1.cc:859
+#line 665 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< PrintNode* > (); }
+#line 2062 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 125:
-#line 660 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< CallNode* > (); }
-#line 2058 "GrammarParser.cpp" // lalr1.cc:859
+#line 666 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< PrintNode* > (); }
+#line 2068 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 126:
-#line 661 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
-#line 2064 "GrammarParser.cpp" // lalr1.cc:859
+#line 667 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UpdateNode* > (); }
+#line 2074 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 127:
-#line 662 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
-#line 2070 "GrammarParser.cpp" // lalr1.cc:859
+#line 668 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< CaseNode* > (); }
+#line 2080 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 128:
-#line 663 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< IfThenElseNode* > (); }
-#line 2076 "GrammarParser.cpp" // lalr1.cc:859
+#line 669 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< CallNode* > (); }
+#line 2086 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 129:
-#line 664 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< LetNode* > (); }
-#line 2082 "GrammarParser.cpp" // lalr1.cc:859
+#line 670 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< IfThenElseNode* > (); }
+#line 2092 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 130:
-#line 665 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< PushNode* > (); }
-#line 2088 "GrammarParser.cpp" // lalr1.cc:859
+#line 671 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< LetNode* > (); }
+#line 2098 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 131:
-#line 666 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< PopNode* > (); }
-#line 2094 "GrammarParser.cpp" // lalr1.cc:859
+#line 672 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< PushNode* > (); }
+#line 2104 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 132:
-#line 667 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< ForallNode* > (); }
-#line 2100 "GrammarParser.cpp" // lalr1.cc:859
+#line 673 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< PopNode* > (); }
+#line 2110 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 133:
-#line 668 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
-#line 2106 "GrammarParser.cpp" // lalr1.cc:859
+#line 674 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< ForallNode* > (); }
+#line 2116 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 134:
-#line 669 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = new AstNode(NodeType::SKIP); }
-#line 2112 "GrammarParser.cpp" // lalr1.cc:859
+#line 675 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
+#line 2122 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 135:
-#line 670 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { driver.error(yylhs.location, "this call syntax is obsolete, use `call "+yystack_[0].value.as< std::string > ()+"`"); }
-#line 2118 "GrammarParser.cpp" // lalr1.cc:859
+#line 676 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = new AstNode(NodeType::SKIP); }
+#line 2128 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 136:
-#line 671 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = new AstNode(NodeType::STATEMENT); }
-#line 2124 "GrammarParser.cpp" // lalr1.cc:859
+#line 677 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { driver.error(yylhs.location, "this call syntax is obsolete, use `call "+yystack_[0].value.as< std::string > ()+"`"); }
+#line 2134 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 137:
-#line 672 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = new AstNode(NodeType::STATEMENT);}
-#line 2130 "GrammarParser.cpp" // lalr1.cc:859
+#line 678 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = new AstNode(NodeType::STATEMENT); }
+#line 2140 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 138:
-#line 675 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::ASSERT, yystack_[0].value.as< ExpressionBase* > ()); }
-#line 2136 "GrammarParser.cpp" // lalr1.cc:859
+#line 679 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = new AstNode(NodeType::STATEMENT);}
+#line 2146 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 139:
-#line 677 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::ASSURE, yystack_[0].value.as< ExpressionBase* > ()); }
-#line 2142 "GrammarParser.cpp" // lalr1.cc:859
+#line 682 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< AstNode* > (); }
+#line 2152 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 140:
-#line 680 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< DiedieNode* > () = new DiedieNode(yylhs.location, yystack_[0].value.as< ExpressionBase* > ()); }
-#line 2148 "GrammarParser.cpp" // lalr1.cc:859
+#line 683 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
+#line 2158 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 141:
-#line 681 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< DiedieNode* > () = new DiedieNode(yylhs.location, nullptr); }
-#line 2154 "GrammarParser.cpp" // lalr1.cc:859
+#line 684 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = yystack_[0].value.as< UnaryNode* > (); }
+#line 2164 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 142:
-#line 691 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstNode* > () = new AstNode(yylhs.location, NodeType::IMPOSSIBLE); }
-#line 2160 "GrammarParser.cpp" // lalr1.cc:859
+#line 687 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::ASSERT, yystack_[0].value.as< ExpressionBase* > ()); }
+#line 2170 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 143:
-#line 694 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< PrintNode* > () = new PrintNode(yylhs.location, yystack_[1].value.as< std::string > (), yystack_[0].value.as< std::vector<ExpressionBase*> > ()); }
-#line 2166 "GrammarParser.cpp" // lalr1.cc:859
+#line 689 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::ASSURE, yystack_[0].value.as< ExpressionBase* > ()); }
+#line 2176 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 144:
-#line 697 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< std::vector<ExpressionBase*> > () = std::move(yystack_[2].value.as< std::vector<ExpressionBase*> > ()); yylhs.value.as< std::vector<ExpressionBase*> > ().push_back(yystack_[0].value.as< ExpressionBase* > ()); }
-#line 2172 "GrammarParser.cpp" // lalr1.cc:859
+#line 692 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< DiedieNode* > () = new DiedieNode(yylhs.location, yystack_[0].value.as< ExpressionBase* > ()); }
+#line 2182 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 145:
-#line 698 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< std::vector<ExpressionBase*> > ().push_back(yystack_[0].value.as< ExpressionBase* > ()); }
-#line 2178 "GrammarParser.cpp" // lalr1.cc:859
+#line 693 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< DiedieNode* > () = new DiedieNode(yylhs.location, nullptr); }
+#line 2188 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 146:
-#line 700 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< PrintNode* > () = new PrintNode(yylhs.location, yystack_[0].value.as< std::vector<ExpressionBase*> > ()); }
-#line 2184 "GrammarParser.cpp" // lalr1.cc:859
+#line 703 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstNode* > () = new AstNode(yylhs.location, NodeType::IMPOSSIBLE); }
+#line 2194 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 147:
-#line 703 "../../src/GrammarParser.yy" // lalr1.cc:859
+#line 706 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< PrintNode* > () = new PrintNode(yylhs.location, yystack_[1].value.as< std::string > (), yystack_[0].value.as< std::vector<ExpressionBase*> > ()); }
+#line 2200 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
+  case 148:
+#line 709 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< std::vector<ExpressionBase*> > () = std::move(yystack_[2].value.as< std::vector<ExpressionBase*> > ()); yylhs.value.as< std::vector<ExpressionBase*> > ().push_back(yystack_[0].value.as< ExpressionBase* > ()); }
+#line 2206 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
+  case 149:
+#line 710 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< std::vector<ExpressionBase*> > ().push_back(yystack_[0].value.as< ExpressionBase* > ()); }
+#line 2212 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
+  case 150:
+#line 712 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< PrintNode* > () = new PrintNode(yylhs.location, yystack_[0].value.as< std::vector<ExpressionBase*> > ()); }
+#line 2218 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
+  case 151:
+#line 715 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
                   if (yystack_[2].value.as< BaseFunctionAtom* > ()->node_type_ == NodeType::FUNCTION_ATOM) {
                     yylhs.value.as< UpdateNode* > () = new UpdateNode(yylhs.location, reinterpret_cast<FunctionAtom*>(yystack_[2].value.as< BaseFunctionAtom* > ()), yystack_[0].value.as< ExpressionBase* > ());
@@ -2193,177 +2227,177 @@ namespace yy {
                                      yystack_[2].value.as< BaseFunctionAtom* > ()->to_str()+"` is a `"+type_to_str(yystack_[2].value.as< BaseFunctionAtom* > ()->node_type_));
                   }
                 }
-#line 2197 "GrammarParser.cpp" // lalr1.cc:859
-    break;
-
-  case 148:
-#line 713 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                yylhs.value.as< CaseNode* > () = new CaseNode(yylhs.location, yystack_[3].value.as< ExpressionBase* > (), yystack_[1].value.as< std::vector<std::pair<AtomNode*, AstNode*>> > ());
-           }
-#line 2205 "GrammarParser.cpp" // lalr1.cc:859
-    break;
-
-  case 149:
-#line 718 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                    yylhs.value.as< std::vector<std::pair<AtomNode*, AstNode*>> > () = std::move(yystack_[1].value.as< std::vector<std::pair<AtomNode*, AstNode*>> > ());
-                    yylhs.value.as< std::vector<std::pair<AtomNode*, AstNode*>> > ().push_back(yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > ());
-               }
-#line 2214 "GrammarParser.cpp" // lalr1.cc:859
-    break;
-
-  case 150:
-#line 722 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                    yylhs.value.as< std::vector<std::pair<AtomNode*, AstNode*>> > () = std::move(std::vector<std::pair<AtomNode*, AstNode*>>());
-                    yylhs.value.as< std::vector<std::pair<AtomNode*, AstNode*>> > ().push_back(yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > ());
-               }
-#line 2223 "GrammarParser.cpp" // lalr1.cc:859
-    break;
-
-  case 151:
-#line 728 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< std::pair<AtomNode*, AstNode*> > () =yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > (); }
-#line 2229 "GrammarParser.cpp" // lalr1.cc:859
+#line 2231 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 152:
-#line 729 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > (); }
-#line 2235 "GrammarParser.cpp" // lalr1.cc:859
+#line 725 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+                yylhs.value.as< CaseNode* > () = new CaseNode(yylhs.location, yystack_[3].value.as< ExpressionBase* > (), yystack_[1].value.as< std::vector<std::pair<AtomNode*, AstNode*>> > ());
+           }
+#line 2239 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 153:
 #line 730 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > (); }
-#line 2241 "GrammarParser.cpp" // lalr1.cc:859
+    {
+                    yylhs.value.as< std::vector<std::pair<AtomNode*, AstNode*>> > () = std::move(yystack_[1].value.as< std::vector<std::pair<AtomNode*, AstNode*>> > ());
+                    yylhs.value.as< std::vector<std::pair<AtomNode*, AstNode*>> > ().push_back(yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > ());
+               }
+#line 2248 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 154:
-#line 731 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > (); }
-#line 2247 "GrammarParser.cpp" // lalr1.cc:859
+#line 734 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+                    yylhs.value.as< std::vector<std::pair<AtomNode*, AstNode*>> > () = std::move(std::vector<std::pair<AtomNode*, AstNode*>>());
+                    yylhs.value.as< std::vector<std::pair<AtomNode*, AstNode*>> > ().push_back(yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > ());
+               }
+#line 2257 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 155:
-#line 734 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                    yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = std::pair<AtomNode*, AstNode*>(nullptr, yystack_[0].value.as< AstNode* > ());
-                  }
-#line 2255 "GrammarParser.cpp" // lalr1.cc:859
-    break;
-
-  case 156:
-#line 739 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                    yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = std::pair<AtomNode*, AstNode*>(yystack_[2].value.as< AtomNode* > (), yystack_[0].value.as< AstNode* > ());
-                 }
+#line 740 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< std::pair<AtomNode*, AstNode*> > () =yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > (); }
 #line 2263 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
+  case 156:
+#line 741 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > (); }
+#line 2269 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
   case 157:
-#line 744 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                    yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = std::pair<AtomNode*, AstNode*>(yystack_[2].value.as< BaseFunctionAtom* > (), yystack_[0].value.as< AstNode* > ());
-                }
-#line 2271 "GrammarParser.cpp" // lalr1.cc:859
+#line 742 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > (); }
+#line 2275 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 158:
-#line 749 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                    yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = std::pair<AtomNode*, AstNode*>(new StringAtom(yylhs.location, std::move(yystack_[2].value.as< std::string > ())), yystack_[0].value.as< AstNode* > ());
-                 }
-#line 2279 "GrammarParser.cpp" // lalr1.cc:859
+#line 743 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = yystack_[0].value.as< std::pair<AtomNode*, AstNode*> > (); }
+#line 2281 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 159:
-#line 754 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< CallNode* > () = new CallNode(yylhs.location, "", yystack_[4].value.as< ExpressionBase* > (), yystack_[1].value.as< std::vector<ExpressionBase*>* > ()); }
-#line 2285 "GrammarParser.cpp" // lalr1.cc:859
+#line 746 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+                    yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = std::pair<AtomNode*, AstNode*>(nullptr, yystack_[0].value.as< AstNode* > ());
+                  }
+#line 2289 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 160:
-#line 755 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< CallNode* > () = new CallNode(yylhs.location, "", yystack_[1].value.as< ExpressionBase* > ()); }
-#line 2291 "GrammarParser.cpp" // lalr1.cc:859
+#line 751 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+                    yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = std::pair<AtomNode*, AstNode*>(yystack_[2].value.as< AtomNode* > (), yystack_[0].value.as< AstNode* > ());
+                 }
+#line 2297 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 161:
 #line 756 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< CallNode* > () = new CallNode(yylhs.location, yystack_[3].value.as< std::string > (), nullptr, yystack_[1].value.as< std::vector<ExpressionBase*>* > ()); }
-#line 2297 "GrammarParser.cpp" // lalr1.cc:859
+    {
+                    yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = std::pair<AtomNode*, AstNode*>(yystack_[2].value.as< BaseFunctionAtom* > (), yystack_[0].value.as< AstNode* > ());
+                }
+#line 2305 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 162:
-#line 757 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< CallNode* > () = new CallNode(yylhs.location, yystack_[0].value.as< std::string > (), nullptr); }
-#line 2303 "GrammarParser.cpp" // lalr1.cc:859
+#line 761 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+                    yylhs.value.as< std::pair<AtomNode*, AstNode*> > () = std::pair<AtomNode*, AstNode*>(new StringAtom(yylhs.location, std::move(yystack_[2].value.as< std::string > ())), yystack_[0].value.as< AstNode* > ());
+                 }
+#line 2313 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 163:
-#line 760 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::SEQBLOCK, yystack_[1].value.as< AstListNode* > ());
-          }
-#line 2311 "GrammarParser.cpp" // lalr1.cc:859
+#line 766 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< CallNode* > () = new CallNode(yylhs.location, "", yystack_[4].value.as< ExpressionBase* > (), yystack_[1].value.as< std::vector<ExpressionBase*>* > ()); }
+#line 2319 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 164:
-#line 763 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::SEQBLOCK, yystack_[1].value.as< AstListNode* > ());
-          }
-#line 2319 "GrammarParser.cpp" // lalr1.cc:859
+#line 767 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< CallNode* > () = new CallNode(yylhs.location, "", yystack_[1].value.as< ExpressionBase* > ()); }
+#line 2325 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 165:
 #line 768 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::PARBLOCK, yystack_[1].value.as< AstListNode* > ());
-          }
-#line 2327 "GrammarParser.cpp" // lalr1.cc:859
+    { yylhs.value.as< CallNode* > () = new CallNode(yylhs.location, yystack_[3].value.as< std::string > (), nullptr, yystack_[1].value.as< std::vector<ExpressionBase*>* > ()); }
+#line 2331 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 166:
-#line 771 "../../src/GrammarParser.yy" // lalr1.cc:859
-    {
-                yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::PARBLOCK, yystack_[1].value.as< AstListNode* > ());
-          }
-#line 2335 "GrammarParser.cpp" // lalr1.cc:859
+#line 769 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< CallNode* > () = new CallNode(yylhs.location, yystack_[0].value.as< std::string > (), nullptr); }
+#line 2337 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 167:
-#line 776 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yystack_[1].value.as< AstListNode* > ()->add(yystack_[0].value.as< AstNode* > ()); yylhs.value.as< AstListNode* > () = yystack_[1].value.as< AstListNode* > (); }
-#line 2341 "GrammarParser.cpp" // lalr1.cc:859
+#line 772 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+                yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::SEQBLOCK, yystack_[1].value.as< AstListNode* > ());
+          }
+#line 2345 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 168:
-#line 777 "../../src/GrammarParser.yy" // lalr1.cc:859
-    { yylhs.value.as< AstListNode* > () = new AstListNode(yylhs.location, NodeType::STATEMENTS); yylhs.value.as< AstListNode* > ()->add(yystack_[0].value.as< AstNode* > ()); }
-#line 2347 "GrammarParser.cpp" // lalr1.cc:859
+#line 775 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+                yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::SEQBLOCK, yystack_[1].value.as< AstListNode* > ());
+          }
+#line 2353 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 169:
 #line 780 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
-                yylhs.value.as< IfThenElseNode* > () = new IfThenElseNode(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< AstNode* > (), nullptr);
+                yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::PARBLOCK, yystack_[1].value.as< AstListNode* > ());
           }
-#line 2355 "GrammarParser.cpp" // lalr1.cc:859
+#line 2361 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 170:
 #line 783 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
-                yylhs.value.as< IfThenElseNode* > () = new IfThenElseNode(yylhs.location, yystack_[4].value.as< ExpressionBase* > (), yystack_[2].value.as< AstNode* > (), yystack_[0].value.as< AstNode* > ());
+                yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::PARBLOCK, yystack_[1].value.as< AstListNode* > ());
           }
-#line 2363 "GrammarParser.cpp" // lalr1.cc:859
+#line 2369 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
   case 171:
+#line 788 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yystack_[1].value.as< AstListNode* > ()->add(yystack_[0].value.as< AstNode* > ()); yylhs.value.as< AstListNode* > () = yystack_[1].value.as< AstListNode* > (); }
+#line 2375 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
+  case 172:
 #line 789 "../../src/GrammarParser.yy" // lalr1.cc:859
+    { yylhs.value.as< AstListNode* > () = new AstListNode(yylhs.location, NodeType::STATEMENTS); yylhs.value.as< AstListNode* > ()->add(yystack_[0].value.as< AstNode* > ()); }
+#line 2381 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
+  case 173:
+#line 792 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+                yylhs.value.as< IfThenElseNode* > () = new IfThenElseNode(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< AstNode* > (), nullptr);
+          }
+#line 2389 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
+  case 174:
+#line 795 "../../src/GrammarParser.yy" // lalr1.cc:859
+    {
+                yylhs.value.as< IfThenElseNode* > () = new IfThenElseNode(yylhs.location, yystack_[4].value.as< ExpressionBase* > (), yystack_[2].value.as< AstNode* > (), yystack_[0].value.as< AstNode* > ());
+          }
+#line 2397 "GrammarParser.cpp" // lalr1.cc:859
+    break;
+
+  case 175:
+#line 801 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
                 auto var = Symbol(yystack_[1].value.as< std::string > (), yylhs.location, Symbol::SymbolType::LET);
                 try {
@@ -2372,20 +2406,20 @@ namespace yy {
                     driver.error(yylhs.location, e.what());
                 }
             }
-#line 2376 "GrammarParser.cpp" // lalr1.cc:859
+#line 2410 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
-  case 172:
-#line 797 "../../src/GrammarParser.yy" // lalr1.cc:859
+  case 176:
+#line 809 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
               driver.function_table.remove(yystack_[5].value.as< std::string > ());
               yylhs.value.as< LetNode* > () = new LetNode(yylhs.location, Type(TypeType::UNKNOWN), yystack_[5].value.as< std::string > (), yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< AstNode* > ());
           }
-#line 2385 "GrammarParser.cpp" // lalr1.cc:859
+#line 2419 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
-  case 173:
-#line 802 "../../src/GrammarParser.yy" // lalr1.cc:859
+  case 177:
+#line 814 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
                 auto var = Symbol(yystack_[3].value.as< std::string > (), yylhs.location, Symbol::SymbolType::LET);
                 try {
@@ -2394,20 +2428,20 @@ namespace yy {
                     driver.error(yylhs.location, e.what());
                 }
             }
-#line 2398 "GrammarParser.cpp" // lalr1.cc:859
+#line 2432 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
-  case 174:
-#line 810 "../../src/GrammarParser.yy" // lalr1.cc:859
+  case 178:
+#line 822 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
               driver.function_table.remove(yystack_[7].value.as< std::string > ());
               yylhs.value.as< LetNode* > () = new LetNode(yylhs.location, yystack_[5].value.as< Type* > (), yystack_[7].value.as< std::string > (), yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< AstNode* > ());
           }
-#line 2407 "GrammarParser.cpp" // lalr1.cc:859
+#line 2441 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
-  case 175:
-#line 816 "../../src/GrammarParser.yy" // lalr1.cc:859
+  case 179:
+#line 828 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
                 if (yystack_[0].value.as< BaseFunctionAtom* > ()->node_type_ == NodeType::BUILTIN_ATOM) {
                   driver.error(yylhs.location, "cannot push to builtin `"+yystack_[0].value.as< BaseFunctionAtom* > ()->to_str()+"`");
@@ -2415,11 +2449,11 @@ namespace yy {
                     yylhs.value.as< PushNode* > () = new PushNode(yylhs.location, yystack_[2].value.as< ExpressionBase* > (), reinterpret_cast<FunctionAtom*>(yystack_[0].value.as< BaseFunctionAtom* > ()));
                 }
           }
-#line 2419 "GrammarParser.cpp" // lalr1.cc:859
+#line 2453 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
-  case 176:
-#line 826 "../../src/GrammarParser.yy" // lalr1.cc:859
+  case 180:
+#line 838 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
                 if (yystack_[2].value.as< BaseFunctionAtom* > ()->node_type_ == NodeType::BUILTIN_ATOM) {
                   driver.error(yylhs.location, "cannot pop to builtin `"+yystack_[2].value.as< BaseFunctionAtom* > ()->to_str()+"`");
@@ -2429,25 +2463,25 @@ namespace yy {
                     yylhs.value.as< PopNode* > () = new PopNode(yylhs.location, reinterpret_cast<FunctionAtom*>(yystack_[2].value.as< BaseFunctionAtom* > ()), reinterpret_cast<FunctionAtom*>(yystack_[0].value.as< BaseFunctionAtom* > ()));
                 }
           }
-#line 2433 "GrammarParser.cpp" // lalr1.cc:859
+#line 2467 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
-  case 177:
-#line 837 "../../src/GrammarParser.yy" // lalr1.cc:859
+  case 181:
+#line 849 "../../src/GrammarParser.yy" // lalr1.cc:859
     {
                 yylhs.value.as< ForallNode* > () = new ForallNode(yylhs.location, yystack_[4].value.as< std::string > (), yystack_[2].value.as< ExpressionBase* > (), yystack_[0].value.as< AstNode* > ());
              }
-#line 2441 "GrammarParser.cpp" // lalr1.cc:859
+#line 2475 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
-  case 178:
-#line 842 "../../src/GrammarParser.yy" // lalr1.cc:859
+  case 182:
+#line 854 "../../src/GrammarParser.yy" // lalr1.cc:859
     { yylhs.value.as< UnaryNode* > () = new UnaryNode(yylhs.location, NodeType::ITERATE, yystack_[0].value.as< AstNode* > ()); }
-#line 2447 "GrammarParser.cpp" // lalr1.cc:859
+#line 2481 "GrammarParser.cpp" // lalr1.cc:859
     break;
 
 
-#line 2451 "GrammarParser.cpp" // lalr1.cc:859
+#line 2485 "GrammarParser.cpp" // lalr1.cc:859
             default:
               break;
             }
@@ -2702,48 +2736,49 @@ namespace yy {
   }
 
 
-  const short int casmi_parser::yypact_ninf_ = -202;
+  const short int casmi_parser::yypact_ninf_ = -203;
 
   const signed char casmi_parser::yytable_ninf_ = -106;
 
   const short int
   casmi_parser::yypact_[] =
   {
-     -23,   -63,    94,   168,  -202,  -202,   -13,   -21,    19,    21,
-      24,    44,    46,   168,  -202,  -202,  -202,  -202,  -202,  -202,
-    -202,  -202,    47,    37,   -45,    72,   -20,  -202,  -202,    79,
-    -202,  -202,    85,    78,   -44,   116,   275,   -54,    70,    88,
-      93,   598,     6,    81,    82,    83,    70,    97,   113,    92,
-     101,  -202,   275,  -202,  -202,  -202,  -202,  -202,    58,    66,
-     275,    31,    89,  -202,  -202,  -202,  -202,   109,  -202,  -202,
-    -202,  -202,  -202,  -202,  -202,   790,  -202,  -202,    -3,   104,
-    -202,   112,   105,   117,    47,    47,   -39,  -202,   275,   275,
-     275,  -202,  -202,   598,   598,    96,   275,   872,   119,   275,
-     120,   129,   598,    -9,   275,   275,   136,   598,   598,    35,
-     160,  -202,  -202,  -202,  -202,  -202,  -202,  -202,  -202,  -202,
-    -202,  -202,  -202,  -202,  -202,  -202,  -202,  -202,  -202,   -18,
-     151,   137,    37,  -202,  -202,   -48,    70,    70,   843,   790,
-    -202,  -202,  -202,  -202,  -202,  -202,   398,  -202,   166,   158,
-     154,   790,  -202,   191,   275,   275,   275,   275,   275,   275,
-     275,   275,   275,   275,   275,   275,   275,   275,   275,   275,
-      70,    70,    25,   146,   275,   162,   167,   598,    93,   790,
-     790,   790,  -202,   356,   419,    62,   514,  -202,   172,   872,
-     577,   207,   222,  -202,   275,   180,   638,  -202,   163,   472,
-     535,   275,    93,   598,   -16,  -202,   116,   165,   169,   174,
-     185,   -32,  -202,  -202,  -202,    59,  -202,   197,  -202,   -31,
-    -202,   275,  -202,   189,   823,   823,   -36,  -202,   335,   335,
-     335,   -36,   -36,   335,   335,   335,  -202,  -202,  -202,   790,
-     195,  -202,   275,    70,  -202,   790,  -202,   206,  -202,  -202,
-    -202,  -202,  -202,  -202,    70,   598,   872,   172,   120,   120,
-     275,   666,   275,    39,   196,  -202,  -202,   790,    18,  -202,
-      93,   598,  -202,    70,  -202,   -34,  -202,  -202,   872,   872,
-     198,   790,  -202,   275,   790,   199,   181,   275,   204,   248,
-    -202,  -202,  -202,   700,   211,   212,   205,   217,   218,   223,
-       3,  -202,  -202,  -202,  -202,  -202,  -202,   598,    61,  -202,
-    -202,   234,  -202,  -202,  -202,   790,   275,  -202,   729,  -202,
-     598,   598,   275,  -202,   598,   598,   598,   598,  -202,  -202,
-    -202,   598,  -202,   790,   598,   275,  -202,  -202,   235,  -202,
-    -202,  -202,  -202,  -202,  -202,   762,  -202,   598,  -202
+     -18,   -69,    41,   382,  -203,  -203,   -47,   -55,   -12,   -10,
+      -7,     2,     5,   382,  -203,  -203,  -203,  -203,  -203,  -203,
+    -203,  -203,     7,    71,   -42,    91,   -14,  -203,  -203,    30,
+    -203,  -203,   104,    97,   -44,   137,   309,   -38,    92,   111,
+     116,   628,   -23,    99,   100,   106,    92,   126,   143,   122,
+     131,  -203,   309,  -203,  -203,  -203,  -203,  -203,   107,   115,
+     309,    37,   124,  -203,  -203,  -203,  -203,   144,  -203,  -203,
+    -203,  -203,  -203,  -203,  -203,   820,  -203,  -203,    39,   139,
+    -203,   146,   140,   151,     7,     7,    -5,  -203,   309,   309,
+     309,  -203,  -203,   628,   628,   132,   309,   930,   133,   309,
+     134,   136,   628,   -45,   309,   309,   156,   628,   628,   -20,
+     168,  -203,  -203,  -203,  -203,  -203,  -203,  -203,  -203,  -203,
+    -203,  -203,  -203,  -203,  -203,  -203,  -203,  -203,  -203,  -203,
+     -16,   159,   145,    71,  -203,  -203,   -49,    92,    92,   901,
+     820,  -203,  -203,  -203,  -203,  -203,  -203,   428,  -203,   174,
+     162,   158,   820,  -203,   285,   309,   309,   309,   309,   309,
+     309,   309,   309,   309,   309,   309,   309,   309,   309,   309,
+     309,    92,    92,    89,   149,   309,   164,   172,   628,   116,
+     820,   820,   820,  -203,  -203,  -203,  -203,   386,   449,    90,
+     544,  -203,   177,   930,   607,   212,   226,  -203,   309,   180,
+     668,  -203,   166,   502,   565,   309,   116,   628,     0,  -203,
+     137,   165,   167,   178,   185,   -28,  -203,  -203,  -203,    82,
+    -203,   198,  -203,    78,  -203,   309,  -203,   189,   853,   853,
+      29,  -203,   881,   881,   881,    29,    29,   881,   881,   881,
+    -203,  -203,  -203,   820,   193,  -203,   309,    92,  -203,   820,
+    -203,   204,  -203,  -203,  -203,  -203,  -203,  -203,    92,   628,
+     930,   177,   134,   134,   309,   696,   309,   123,   194,  -203,
+    -203,   820,    16,  -203,   116,   628,  -203,    92,  -203,   -29,
+    -203,  -203,   930,   930,   195,   820,  -203,   309,   820,   197,
+     181,   309,   202,   241,  -203,  -203,  -203,   730,   203,   201,
+     206,   208,   209,   210,    13,  -203,  -203,  -203,  -203,  -203,
+    -203,   628,    24,  -203,  -203,   207,  -203,  -203,  -203,   820,
+     309,  -203,   759,  -203,   628,   628,   309,  -203,   628,   628,
+     628,   628,  -203,  -203,  -203,   628,  -203,   820,   628,   309,
+    -203,  -203,   217,  -203,  -203,  -203,  -203,  -203,  -203,   792,
+    -203,   628,  -203
   };
 
   const unsigned char
@@ -2757,205 +2792,215 @@ namespace yy {
        0,    25,     0,    65,    66,    67,    68,    64,     0,     0,
        0,     0,     0,    75,    71,    78,    61,   105,   103,    57,
       72,    60,    59,    63,    62,    18,    58,    56,     0,    34,
-      38,     0,    35,     0,     0,     0,     0,   115,     0,     0,
-     141,   142,   134,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   135,
-       0,   108,   117,   118,   119,   120,   121,   122,   123,   124,
-     125,   126,   127,   128,   129,   130,   131,   132,   133,     0,
-       0,     0,     0,    29,    31,     0,     0,    40,     0,   102,
-      73,    69,    76,    74,    70,    77,     0,    82,    60,     0,
-      83,    86,    79,     0,     0,     0,     0,     0,     0,     0,
+      38,     0,    35,     0,     0,     0,     0,   118,     0,     0,
+     145,   146,   135,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   136,
+       0,   111,   110,   120,   121,   122,   123,   124,   125,   126,
+     127,   128,   108,   109,   129,   130,   131,   132,   133,   134,
+       0,     0,     0,     0,    29,    31,     0,     0,    40,     0,
+     102,    73,    69,    76,    74,    70,    77,     0,    82,    60,
+       0,    83,    86,    79,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,    36,     0,     0,     0,     0,     0,   138,
-     139,   140,   168,     0,     0,     0,     0,   145,   146,     0,
-       0,     0,     0,   178,     0,   162,     0,   136,     0,     0,
-       0,     0,     0,     0,     0,    15,    24,     0,     0,    48,
-       0,     0,    32,    39,    50,     0,    53,    54,   104,     0,
-      81,    84,   106,     0,   101,    99,   100,    92,    93,    97,
-      98,    87,    88,    94,    95,    96,    89,    90,    91,    19,
-       0,    33,     0,     0,    37,    21,    16,     0,   111,   114,
-     164,   167,   166,   171,     0,     0,     0,   143,     0,     0,
-       0,     0,     0,     0,     0,   163,   165,   147,     0,   109,
-       0,     0,    23,    47,    43,     0,    45,    49,    52,     0,
-       0,    85,   107,     0,    17,     0,     0,     0,     0,   169,
-     144,   175,   176,     0,   160,     0,     0,     0,     0,     0,
-       0,   150,   151,   152,   153,   154,   137,     0,     0,   110,
-      46,     0,    51,    55,    80,    22,     0,   116,     0,   173,
-       0,     0,     0,   161,     0,     0,     0,     0,   148,   149,
-     112,     0,    44,    20,     0,     0,   170,   177,     0,   155,
-     158,   156,   157,   113,   172,     0,   159,     0,   174
+       0,     0,     0,     0,    36,     0,     0,     0,     0,     0,
+     142,   143,   144,   139,   172,   140,   141,     0,     0,     0,
+       0,   149,   150,     0,     0,     0,     0,   182,     0,   166,
+       0,   137,     0,     0,     0,     0,     0,     0,     0,    15,
+      24,     0,     0,    48,     0,     0,    32,    39,    50,     0,
+      53,    54,   104,     0,    81,    84,   106,     0,   101,    99,
+     100,    92,    93,    97,    98,    87,    88,    94,    95,    96,
+      89,    90,    91,    19,     0,    33,     0,     0,    37,    21,
+      16,     0,   114,   117,   168,   171,   170,   175,     0,     0,
+       0,   147,     0,     0,     0,     0,     0,     0,     0,   167,
+     169,   151,     0,   112,     0,     0,    23,    47,    43,     0,
+      45,    49,    52,     0,     0,    85,   107,     0,    17,     0,
+       0,     0,     0,   173,   148,   179,   180,     0,   164,     0,
+       0,     0,     0,     0,     0,   154,   155,   156,   157,   158,
+     138,     0,     0,   113,    46,     0,    51,    55,    80,    22,
+       0,   119,     0,   177,     0,     0,     0,   165,     0,     0,
+       0,     0,   152,   153,   115,     0,    44,    20,     0,     0,
+     174,   181,     0,   159,   162,   160,   161,   116,   176,     0,
+     163,     0,   178
   };
 
   const short int
   casmi_parser::yypgoto_[] =
   {
-    -202,  -202,  -202,  -202,   269,  -202,  -202,  -202,  -202,  -202,
-    -202,   -28,  -202,   171,   128,   262,  -202,   170,   -30,    36,
-     102,  -202,    33,   -80,  -202,  -131,   -59,  -202,  -202,  -202,
-     -99,  -202,    27,  -202,   -41,  -202,  -201,   134,   -29,  -202,
-    -202,  -202,  -202,  -202,   124,  -202,  -202,  -202,  -202,    15,
-    -202,  -202,  -202,  -202,  -202,  -202,  -202,   -85,  -202,  -202,
-    -202,  -202,  -202,  -202,  -202,  -202
+    -203,  -203,  -203,  -203,   255,  -203,  -203,  -203,  -203,  -203,
+    -203,    28,  -203,   141,    95,   231,  -203,   147,   -22,    -2,
+      83,  -203,    10,   -82,  -203,  -131,   -58,  -203,  -203,  -203,
+     -85,  -203,   -34,  -203,   -41,  -167,  -203,  -202,   117,   -40,
+     -11,  -203,  -203,  -203,  -203,  -203,   105,  -203,  -203,  -203,
+    -203,    -3,  -203,  -203,  -203,  -203,  -203,   -35,   -33,   -30,
+    -203,  -203,  -203,  -203,  -203,  -203,  -203,  -203
   };
 
   const short int
   casmi_parser::yydefgoto_[] =
   {
       -1,     2,     3,    13,    14,    15,    16,    17,    18,    19,
-      20,    32,    33,    35,    80,    81,    82,    48,    49,   210,
-      51,   215,   216,    68,    69,    70,    71,    72,    73,    74,
-     149,   150,   151,    76,    77,    21,    86,    87,   182,   112,
-     113,   114,   115,   116,   188,   117,   118,   119,   300,   301,
-     302,   303,   304,   305,   120,   121,   122,   183,   123,   124,
-     287,   335,   125,   126,   127,   128
+      20,    32,    33,    35,    80,    81,    82,    48,    49,   214,
+      51,   219,   220,    68,    69,    70,    71,    72,    73,    74,
+     150,   151,   152,    76,    77,   111,    21,    86,    87,   183,
+     184,   113,   114,   115,   116,   117,   192,   118,   119,   120,
+     304,   305,   306,   307,   308,   309,   121,   185,   186,   187,
+     124,   125,   291,   339,   126,   127,   128,   129
   };
 
   const short int
   casmi_parser::yytable_[] =
   {
-     110,   268,   148,    40,   211,   202,   197,   270,    83,   184,
-      46,    78,   111,   207,   208,   157,   134,   187,    36,    37,
-       4,   275,   199,   200,   177,     1,    38,   207,   208,    79,
-      58,    59,    64,   276,   178,    47,   296,    52,   328,    47,
-     166,   167,   168,    41,    42,   203,    64,   271,    63,    64,
-      65,    22,   110,   110,   223,   194,   175,   176,   217,   191,
-     169,   110,    24,    75,    58,    59,   110,   110,   170,   308,
-      23,   129,   296,   193,   195,    53,    54,    55,    56,   139,
-      57,   307,    63,    64,    65,   297,    67,   146,   242,    79,
-    -105,   178,    58,    59,     5,    60,   243,    61,   147,   153,
-      58,    59,    25,    62,    26,   209,   212,    27,    34,   187,
-      63,    64,    65,    66,    67,   179,   180,   181,    63,    64,
-      65,   297,    67,   186,   331,   253,   190,    28,   277,    29,
-      31,   196,   278,   254,   178,    39,   110,   140,   141,   142,
-     240,   241,   110,   110,   311,   143,   144,   145,   248,    43,
-      44,    45,    50,    47,   251,   251,    84,    85,   110,   110,
-     280,   135,   110,   295,   131,   132,   133,   136,   137,   138,
-     251,   251,   152,   153,   269,   171,   290,   172,   173,   185,
-     174,   224,   225,   226,   227,   228,   229,   230,   231,   232,
-     233,   234,   235,   236,   237,   238,   239,    52,   217,   313,
-     198,   245,   189,    67,   298,     6,     7,     8,     9,    10,
-      11,    12,   192,   285,   110,   201,   204,   291,   292,   219,
-     205,   261,   299,   338,   288,   220,   289,   221,   267,    79,
-     110,   246,   247,   256,   259,    53,    54,    55,    56,   260,
-      57,   298,   309,   209,   262,   141,   264,   273,   281,   144,
-     274,   279,    58,    59,   282,    60,   222,    61,   283,   299,
-     286,   306,   316,    62,   317,   314,   110,   319,   320,   284,
-      63,    64,    65,    66,    67,   322,   324,   323,   330,   110,
-     110,    52,    30,   110,   110,   110,   110,   293,   325,   326,
-     110,   336,   337,   110,   327,   339,   340,   341,   342,   332,
-     346,   244,   343,   206,   130,   344,   110,   213,   272,   310,
-     315,   312,   249,   257,   318,   329,     0,     0,   348,    53,
+     110,   112,    75,   149,   272,   215,   122,   206,   123,    40,
+      46,   252,   211,   212,     4,   191,    83,    22,   140,   198,
+     201,    36,    37,   274,   135,   279,   147,    78,    24,    38,
+       1,    64,   211,   212,    47,  -105,    23,   280,   199,    47,
+     273,     5,   130,    52,   154,    79,   300,   207,   332,    41,
+      42,    64,   110,   110,   180,   181,   182,   221,   178,   195,
+      79,   110,   190,   275,   188,   194,   110,   110,   179,   227,
+     200,    25,   312,    26,    58,    59,    27,   203,   204,   311,
+     158,    53,    54,    55,    56,    28,    57,   335,    29,   179,
+      31,   197,    63,    64,    65,   301,    67,   179,    58,    59,
+      43,    60,   170,    61,   148,   167,   168,   169,   313,    62,
+     171,   191,   176,   177,   213,   216,    63,    64,    65,    66,
+      67,   228,   229,   230,   231,   232,   233,   234,   235,   236,
+     237,   238,   239,   240,   241,   242,   243,   110,   112,    58,
+      59,   249,    34,   122,   334,   123,   110,   110,   315,   244,
+     245,   281,   246,   257,    39,   282,   300,    63,    64,    65,
+     247,   258,   110,   110,   265,   284,   110,   112,   347,    44,
+      45,   271,   122,    50,   123,    47,   255,   255,   294,    84,
+      85,   299,   132,   133,    58,    59,   141,   142,   143,   134,
+     136,   285,   255,   255,   144,   145,   146,   137,   138,   139,
+     221,   317,    63,    64,    65,   301,    67,   153,   154,   302,
+     172,   173,   288,   174,   175,   189,   193,    67,   110,   196,
+     202,   295,   296,   205,   208,   289,   303,   223,   209,   224,
+     297,   225,    79,   250,   110,   112,   292,   251,   260,   263,
+     122,   342,   123,   264,   266,   142,   302,   145,   293,   268,
+     278,   277,   283,   319,   286,   213,   287,   322,   290,   310,
+     320,   324,   318,   303,   321,   323,   327,   326,    30,   248,
+     110,   112,   336,   131,   210,   314,   122,   328,   123,   329,
+     330,   331,   350,   110,   110,   217,   337,   110,   110,   110,
+     110,    52,   316,   276,   110,   112,   253,   110,   261,     0,
+     122,   333,   123,     0,     0,   349,     0,     0,     0,     0,
+     110,     0,     0,   340,   341,    52,     0,   343,   344,   345,
+     346,     0,     0,     0,     0,     0,     0,   348,     0,    53,
       54,    55,    56,     0,    57,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,    58,    59,     0,    60,
-     156,    61,     0,   333,     0,     0,     0,    62,     0,     0,
+     352,     0,     0,     0,     0,     0,    58,    59,     0,    60,
+     226,    61,     0,    53,    54,    55,    56,    62,    57,     0,
        0,     0,     0,     0,    63,    64,    65,    66,    67,     0,
-       0,     0,   345,    88,    89,    90,    91,    92,    93,   250,
+      58,    59,     0,    60,     0,    61,     0,     0,     0,     0,
+       0,    62,     0,     0,     0,     0,     0,     0,    63,    64,
+      65,    66,    67,    88,    89,    90,    91,    92,    93,   254,
       94,     0,    95,     0,    96,     0,     0,    97,    98,     0,
-      99,     0,   100,     0,   101,   102,   157,   103,   104,     0,
-       0,  -106,  -106,  -106,     0,     0,   161,   162,  -106,     0,
-       0,   154,   155,   156,     0,     0,   105,     0,   106,  -106,
-    -106,   166,   167,   168,     0,   107,     0,     0,     0,     0,
+      99,     0,   100,     0,   101,   102,     0,   103,   104,     6,
+       7,     8,     9,    10,    11,    12,     0,     0,     0,     0,
+       0,   155,   156,   157,     0,     0,   105,     0,   106,     0,
+       0,     0,     0,     0,     0,   107,     0,     0,     0,     0,
        0,     0,     0,     0,   108,     0,    88,    89,    90,    91,
-      92,    93,     0,    94,   252,    95,     0,    96,     0,   109,
-      97,    98,     0,    99,     0,   100,     0,   101,   102,   157,
-     103,   104,     0,     0,   158,   159,   160,     0,     0,   161,
-     162,   163,     0,   218,     0,     0,     0,     0,     0,   105,
-       0,   106,   164,   165,   166,   167,   168,     0,   107,    88,
+      92,    93,     0,    94,   256,    95,     0,    96,     0,   109,
+      97,    98,     0,    99,     0,   100,     0,   101,   102,   158,
+     103,   104,     0,     0,   159,   160,   161,     0,     0,   162,
+     163,   164,     0,   222,     0,     0,     0,     0,     0,   105,
+       0,   106,   165,   166,   167,   168,   169,     0,   107,    88,
       89,    90,    91,    92,    93,     0,    94,   108,    95,     0,
       96,     0,     0,    97,    98,     0,    99,     0,   100,     0,
      101,   102,   109,   103,   104,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   154,   155,   156,
+       0,     0,     0,     0,     0,     0,     0,   155,   156,   157,
        0,     0,   105,     0,   106,     0,     0,     0,     0,     0,
-       0,   107,   265,   255,     0,     0,     0,     0,     0,     0,
+       0,   107,   269,   259,     0,     0,     0,     0,     0,     0,
      108,     0,    88,    89,    90,    91,    92,    93,     0,    94,
        0,    95,     0,    96,     0,   109,    97,    98,     0,    99,
-       0,   100,     0,   101,   102,   157,   103,   104,     0,     0,
-     158,   159,   160,     0,     0,   161,   162,   163,     0,     0,
-     154,   155,   156,     0,     0,   105,     0,   106,   164,   165,
-     166,   167,   168,     0,   107,     0,     0,     0,     0,     0,
-       0,     0,   258,   108,   266,    88,    89,    90,    91,    92,
+       0,   100,     0,   101,   102,   158,   103,   104,     0,     0,
+     159,   160,   161,     0,     0,   162,   163,   164,     0,     0,
+     155,   156,   157,     0,     0,   105,     0,   106,   165,   166,
+     167,   168,   169,     0,   107,     0,     0,     0,     0,     0,
+       0,     0,   262,   108,   270,    88,    89,    90,    91,    92,
       93,     0,    94,     0,    95,     0,    96,     0,   109,    97,
-      98,     0,    99,     0,   100,     0,   101,   102,   157,   103,
-     104,     0,     0,   158,   159,   160,     0,     0,   161,   162,
-     163,   154,   155,   156,     0,     0,     0,     0,   105,     0,
-     106,   164,   165,   166,   167,   168,     0,   107,     0,     0,
-       0,     0,     0,     0,     0,     0,   108,     0,     0,   154,
-     155,   156,   263,     0,     0,     0,     0,     0,     0,     0,
-       0,   109,     0,     0,     0,     0,     0,     0,     0,   157,
-       0,     0,     0,     0,   158,   159,   160,     0,     0,   161,
-     162,   163,     0,   154,   155,   156,     0,     0,     0,     0,
-       0,     0,   164,   165,   166,   167,   168,   157,     0,     0,
-       0,     0,   158,   159,   160,     0,     0,   161,   162,   163,
-     321,   294,   154,   155,   156,     0,     0,     0,     0,     0,
-     164,   165,   166,   167,   168,     0,   334,     0,     0,     0,
-       0,   157,     0,     0,     0,     0,   158,   159,   160,     0,
-       0,   161,   162,   163,     0,   154,   155,   156,     0,     0,
-       0,     0,     0,     0,   164,   165,   166,   167,   168,   347,
-     157,     0,     0,     0,     0,   158,   159,   160,     0,     0,
-     161,   162,   163,   154,   155,   156,     0,     0,     0,     0,
-       0,     0,     0,   164,   165,   166,   167,   168,     0,     0,
-       0,     0,     0,   157,     0,     0,     0,     0,   158,   159,
-     160,     0,     0,   161,   162,   163,  -106,  -106,   156,     0,
-       0,     0,     0,     0,     0,     0,   164,   165,   166,   167,
-     168,   157,     0,     0,     0,     0,   158,   159,   160,     0,
-       0,   161,   162,   163,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   164,   165,   166,   167,   168,     0,
-       0,     0,     0,     0,   157,     0,     0,     0,     0,   158,
-     159,   160,     0,     0,   161,   162,   163,    53,    54,    55,
-      56,     0,    57,     0,     0,     0,     0,   164,   165,   166,
-     167,   168,     0,     0,    58,    59,     0,    60,     0,    61,
-       0,     0,   214,     0,     0,    62,    53,    54,    55,    56,
-       0,    57,    63,    64,    65,    66,    67,     0,     0,     0,
-       0,     0,     0,    58,    59,     0,    60,     0,    61,     0,
-       0,     0,     0,     0,    62,     0,     0,     0,     0,     0,
-       0,    63,    64,    65,    66,    67
+      98,     0,    99,     0,   100,     0,   101,   102,   158,   103,
+     104,     0,     0,   159,   160,   161,     0,     0,   162,   163,
+     164,   155,   156,   157,     0,     0,     0,     0,   105,     0,
+     106,   165,   166,   167,   168,   169,     0,   107,     0,     0,
+       0,     0,     0,     0,     0,     0,   108,     0,     0,   155,
+     156,   157,   267,     0,     0,     0,     0,     0,     0,     0,
+       0,   109,     0,     0,     0,     0,     0,     0,     0,   158,
+       0,     0,     0,     0,   159,   160,   161,     0,     0,   162,
+     163,   164,     0,   155,   156,   157,     0,     0,     0,     0,
+       0,     0,   165,   166,   167,   168,   169,   158,     0,     0,
+       0,     0,   159,   160,   161,     0,     0,   162,   163,   164,
+     325,   298,   155,   156,   157,     0,     0,     0,     0,     0,
+     165,   166,   167,   168,   169,     0,   338,     0,     0,     0,
+       0,   158,     0,     0,     0,     0,   159,   160,   161,     0,
+       0,   162,   163,   164,     0,   155,   156,   157,     0,     0,
+       0,     0,     0,     0,   165,   166,   167,   168,   169,   351,
+     158,     0,     0,     0,     0,   159,   160,   161,     0,     0,
+     162,   163,   164,   155,   156,   157,     0,     0,     0,     0,
+       0,     0,     0,   165,   166,   167,   168,   169,     0,     0,
+       0,     0,     0,   158,     0,     0,     0,     0,   159,   160,
+     161,     0,     0,   162,   163,   164,  -106,  -106,   157,     0,
+       0,     0,     0,     0,     0,     0,   165,   166,   167,   168,
+     169,   158,     0,     0,     0,     0,   159,   160,   161,     0,
+       0,   162,   163,   164,     0,     0,   157,     0,     0,     0,
+       0,     0,     0,     0,   165,   166,   167,   168,   169,     0,
+       0,     0,     0,     0,   158,     0,     0,     0,     0,   159,
+     160,   161,     0,     0,   162,   163,   164,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   165,   166,   167,
+     168,   169,   158,     0,     0,     0,     0,  -106,  -106,  -106,
+       0,     0,   162,   163,  -106,    53,    54,    55,    56,     0,
+      57,     0,     0,     0,     0,  -106,  -106,   167,   168,   169,
+       0,     0,    58,    59,     0,    60,     0,    61,     0,     0,
+     218,     0,     0,    62,    53,    54,    55,    56,     0,    57,
+      63,    64,    65,    66,    67,     0,     0,     0,     0,     0,
+       0,    58,    59,     0,    60,     0,    61,     0,     0,     0,
+       0,     0,    62,     0,     0,     0,     0,     0,     0,    63,
+      64,    65,    66,    67
   };
 
   const short int
   casmi_parser::yycheck_[] =
   {
-      41,   202,    61,    23,   135,    23,   105,    23,    38,    94,
-      54,    65,    41,    61,    62,    51,    46,    97,    63,    64,
-      83,    53,   107,   108,    63,    48,    71,    61,    62,    83,
-      61,    62,    80,    65,    73,    83,    33,     6,    35,    83,
-      76,    77,    78,    63,    64,    63,    80,    63,    79,    80,
-      81,    64,    93,    94,   153,    64,    84,    85,   138,   100,
-      63,   102,    83,    36,    61,    62,   107,   108,    71,   270,
-      83,    65,    33,   102,    83,    44,    45,    46,    47,    52,
-      49,    63,    79,    80,    81,    82,    83,    60,    63,    83,
-      55,    73,    61,    62,     0,    64,    71,    66,    67,    64,
-      61,    62,    83,    72,    83,   135,   136,    83,    71,   189,
-      79,    80,    81,    82,    83,    88,    89,    90,    79,    80,
-      81,    82,    83,    96,    63,    63,    99,    83,    69,    83,
-      83,   104,    73,    71,    73,    63,   177,    79,    80,    81,
-     170,   171,   183,   184,   275,    79,    80,    81,   177,    70,
-      65,    73,    36,    83,   183,   184,    68,    64,   199,   200,
-     219,    64,   203,   262,    83,    83,    83,    54,    76,    68,
-     199,   200,    83,    64,   203,    71,   256,    65,    73,    83,
-      63,   154,   155,   156,   157,   158,   159,   160,   161,   162,
-     163,   164,   165,   166,   167,   168,   169,     6,   278,   279,
-      64,   174,    83,    83,   263,    37,    38,    39,    40,    41,
-      42,    43,    83,   243,   255,    55,    65,   258,   259,    53,
-      83,   194,   263,   322,   254,    67,   255,    73,   201,    83,
-     271,    69,    65,    61,    27,    44,    45,    46,    47,    17,
-      49,   300,   271,   273,    64,    80,    83,    73,   221,    80,
-      65,    54,    61,    62,    65,    64,    65,    66,    63,   300,
-      54,    65,    63,    72,    83,    67,   307,    63,    20,   242,
-      79,    80,    81,    82,    83,    64,    71,    65,   307,   320,
-     321,     6,    13,   324,   325,   326,   327,   260,    71,    71,
-     331,   320,   321,   334,    71,   324,   325,   326,   327,    65,
-      65,   173,   331,   132,    42,   334,   347,   137,   206,   273,
-     283,   278,   178,   189,   287,   300,    -1,    -1,   347,    44,
+      41,    41,    36,    61,   206,   136,    41,    23,    41,    23,
+      54,   178,    61,    62,    83,    97,    38,    64,    52,    64,
+     105,    63,    64,    23,    46,    53,    60,    65,    83,    71,
+      48,    80,    61,    62,    83,    55,    83,    65,    83,    83,
+     207,     0,    65,     6,    64,    83,    33,    63,    35,    63,
+      64,    80,    93,    94,    88,    89,    90,   139,    63,   100,
+      83,   102,    96,    63,    94,    99,   107,   108,    73,   154,
+     104,    83,   274,    83,    61,    62,    83,   107,   108,    63,
+      51,    44,    45,    46,    47,    83,    49,    63,    83,    73,
+      83,   102,    79,    80,    81,    82,    83,    73,    61,    62,
+      70,    64,    63,    66,    67,    76,    77,    78,   275,    72,
+      71,   193,    84,    85,   136,   137,    79,    80,    81,    82,
+      83,   155,   156,   157,   158,   159,   160,   161,   162,   163,
+     164,   165,   166,   167,   168,   169,   170,   178,   178,    61,
+      62,   175,    71,   178,   311,   178,   187,   188,   279,   171,
+     172,    69,    63,    63,    63,    73,    33,    79,    80,    81,
+      71,    71,   203,   204,   198,   223,   207,   207,   335,    65,
+      73,   205,   207,    36,   207,    83,   187,   188,   260,    68,
+      64,   266,    83,    83,    61,    62,    79,    80,    81,    83,
+      64,   225,   203,   204,    79,    80,    81,    54,    76,    68,
+     282,   283,    79,    80,    81,    82,    83,    83,    64,   267,
+      71,    65,   246,    73,    63,    83,    83,    83,   259,    83,
+      64,   262,   263,    55,    65,   247,   267,    53,    83,    67,
+     264,    73,    83,    69,   275,   275,   258,    65,    61,    27,
+     275,   326,   275,    17,    64,    80,   304,    80,   259,    83,
+      65,    73,    54,   287,    65,   277,    63,   291,    54,    65,
+      63,    20,    67,   304,    83,    63,    65,    64,    13,   174,
+     311,   311,    65,    42,   133,   277,   311,    71,   311,    71,
+      71,    71,    65,   324,   325,   138,   320,   328,   329,   330,
+     331,     6,   282,   210,   335,   335,   179,   338,   193,    -1,
+     335,   304,   335,    -1,    -1,   339,    -1,    -1,    -1,    -1,
+     351,    -1,    -1,   324,   325,     6,    -1,   328,   329,   330,
+     331,    -1,    -1,    -1,    -1,    -1,    -1,   338,    -1,    44,
       45,    46,    47,    -1,    49,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    61,    62,    -1,    64,
-       5,    66,    -1,   316,    -1,    -1,    -1,    72,    -1,    -1,
+     351,    -1,    -1,    -1,    -1,    -1,    61,    62,    -1,    64,
+      65,    66,    -1,    44,    45,    46,    47,    72,    49,    -1,
       -1,    -1,    -1,    -1,    79,    80,    81,    82,    83,    -1,
-      -1,    -1,   335,     7,     8,     9,    10,    11,    12,    13,
+      61,    62,    -1,    64,    -1,    66,    -1,    -1,    -1,    -1,
+      -1,    72,    -1,    -1,    -1,    -1,    -1,    -1,    79,    80,
+      81,    82,    83,     7,     8,     9,    10,    11,    12,    13,
       14,    -1,    16,    -1,    18,    -1,    -1,    21,    22,    -1,
-      24,    -1,    26,    -1,    28,    29,    51,    31,    32,    -1,
-      -1,    56,    57,    58,    -1,    -1,    61,    62,    63,    -1,
-      -1,     3,     4,     5,    -1,    -1,    50,    -1,    52,    74,
-      75,    76,    77,    78,    -1,    59,    -1,    -1,    -1,    -1,
+      24,    -1,    26,    -1,    28,    29,    -1,    31,    32,    37,
+      38,    39,    40,    41,    42,    43,    -1,    -1,    -1,    -1,
+      -1,     3,     4,     5,    -1,    -1,    50,    -1,    52,    -1,
+      -1,    -1,    -1,    -1,    -1,    59,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    68,    -1,     7,     8,     9,    10,
       11,    12,    -1,    14,    15,    16,    -1,    18,    -1,    83,
       21,    22,    -1,    24,    -1,    26,    -1,    28,    29,    51,
@@ -2999,17 +3044,20 @@ namespace yy {
       58,    -1,    -1,    61,    62,    63,     3,     4,     5,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    74,    75,    76,    77,
       78,    51,    -1,    -1,    -1,    -1,    56,    57,    58,    -1,
-      -1,    61,    62,    63,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    61,    62,    63,    -1,    -1,     5,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    74,    75,    76,    77,    78,    -1,
       -1,    -1,    -1,    -1,    51,    -1,    -1,    -1,    -1,    56,
-      57,    58,    -1,    -1,    61,    62,    63,    44,    45,    46,
-      47,    -1,    49,    -1,    -1,    -1,    -1,    74,    75,    76,
-      77,    78,    -1,    -1,    61,    62,    -1,    64,    -1,    66,
-      -1,    -1,    69,    -1,    -1,    72,    44,    45,    46,    47,
-      -1,    49,    79,    80,    81,    82,    83,    -1,    -1,    -1,
-      -1,    -1,    -1,    61,    62,    -1,    64,    -1,    66,    -1,
-      -1,    -1,    -1,    -1,    72,    -1,    -1,    -1,    -1,    -1,
-      -1,    79,    80,    81,    82,    83
+      57,    58,    -1,    -1,    61,    62,    63,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    74,    75,    76,
+      77,    78,    51,    -1,    -1,    -1,    -1,    56,    57,    58,
+      -1,    -1,    61,    62,    63,    44,    45,    46,    47,    -1,
+      49,    -1,    -1,    -1,    -1,    74,    75,    76,    77,    78,
+      -1,    -1,    61,    62,    -1,    64,    -1,    66,    -1,    -1,
+      69,    -1,    -1,    72,    44,    45,    46,    47,    -1,    49,
+      79,    80,    81,    82,    83,    -1,    -1,    -1,    -1,    -1,
+      -1,    61,    62,    -1,    64,    -1,    66,    -1,    -1,    -1,
+      -1,    -1,    72,    -1,    -1,    -1,    -1,    -1,    -1,    79,
+      80,    81,    82,    83
   };
 
   const unsigned char
@@ -3017,39 +3065,40 @@ namespace yy {
   {
        0,    48,    88,    89,    83,     0,    37,    38,    39,    40,
       41,    42,    43,    90,    91,    92,    93,    94,    95,    96,
-      97,   122,    64,    83,    83,    83,    83,    83,    83,    83,
+      97,   123,    64,    83,    83,    83,    83,    83,    83,    83,
       91,    83,    98,    99,    71,   100,    63,    64,    71,    63,
       23,    63,    64,    70,    65,    73,    54,    83,   104,   105,
       36,   107,     6,    44,    45,    46,    47,    49,    61,    62,
       64,    66,    72,    79,    80,    81,    82,    83,   110,   111,
      112,   113,   114,   115,   116,   119,   120,   121,    65,    83,
-     101,   102,   103,   105,    68,    64,   123,   124,     7,     8,
+     101,   102,   103,   105,    68,    64,   124,   125,     7,     8,
        9,    10,    11,    12,    14,    16,    18,    21,    22,    24,
       26,    28,    29,    31,    32,    50,    52,    59,    68,    83,
-     121,   125,   126,   127,   128,   129,   130,   132,   133,   134,
-     141,   142,   143,   145,   146,   149,   150,   151,   152,    65,
-     102,    83,    83,    83,   105,    64,    54,    76,    68,   119,
-      79,    80,    81,    79,    80,    81,   119,    67,   113,   117,
-     118,   119,    83,    64,     3,     4,     5,    51,    56,    57,
-      58,    61,    62,    63,    74,    75,    76,    77,    78,    63,
-      71,    71,    65,    73,    63,    98,    98,    63,    73,   119,
-     119,   119,   125,   144,   144,    83,   119,   110,   131,    83,
-     119,   121,    83,   125,    64,    83,   119,   117,    64,   144,
-     144,    55,    23,    63,    65,    83,   100,    61,    62,   105,
-     106,   112,   105,   104,    69,   108,   109,   110,    65,    53,
-      67,    73,    65,   117,   119,   119,   119,   119,   119,   119,
+     121,   122,   126,   128,   129,   130,   131,   132,   134,   135,
+     136,   143,   144,   145,   147,   148,   151,   152,   153,   154,
+      65,   102,    83,    83,    83,   105,    64,    54,    76,    68,
+     119,    79,    80,    81,    79,    80,    81,   119,    67,   113,
+     117,   118,   119,    83,    64,     3,     4,     5,    51,    56,
+      57,    58,    61,    62,    63,    74,    75,    76,    77,    78,
+      63,    71,    71,    65,    73,    63,    98,    98,    63,    73,
+     119,   119,   119,   126,   127,   144,   145,   146,   146,    83,
+     119,   110,   133,    83,   119,   121,    83,   127,    64,    83,
+     119,   117,    64,   146,   146,    55,    23,    63,    65,    83,
+     100,    61,    62,   105,   106,   112,   105,   104,    69,   108,
+     109,   110,    65,    53,    67,    73,    65,   117,   119,   119,
      119,   119,   119,   119,   119,   119,   119,   119,   119,   119,
-     105,   105,    63,    71,   101,   119,    69,    65,   125,   124,
-      13,   125,    15,    63,    71,    19,    61,   131,    25,    27,
-      17,   119,    64,    34,    83,    60,    69,   119,   123,   125,
-      23,    63,   107,    73,    65,    53,    65,    69,    73,    54,
-     113,   119,    65,    63,   119,   105,    54,   147,   105,   125,
-     110,   121,   121,   119,    65,   117,    33,    82,   113,   121,
-     135,   136,   137,   138,   139,   140,    65,    63,   123,   125,
-     106,   112,   109,   110,    67,   119,    63,    83,   119,    63,
-      20,    30,    64,    65,    71,    71,    71,    71,    35,   136,
-     125,    63,    65,   119,    17,   148,   125,   125,   117,   125,
-     125,   125,   125,   125,   125,   119,    65,    17,   125
+     119,   119,   119,   119,   105,   105,    63,    71,   101,   119,
+      69,    65,   122,   125,    13,   127,    15,    63,    71,    19,
+      61,   133,    25,    27,    17,   119,    64,    34,    83,    60,
+      69,   119,   124,   122,    23,    63,   107,    73,    65,    53,
+      65,    69,    73,    54,   113,   119,    65,    63,   119,   105,
+      54,   149,   105,   127,   110,   121,   121,   119,    65,   117,
+      33,    82,   113,   121,   137,   138,   139,   140,   141,   142,
+      65,    63,   124,   122,   106,   112,   109,   110,    67,   119,
+      63,    83,   119,    63,    20,    30,    64,    65,    71,    71,
+      71,    71,    35,   138,   122,    63,    65,   119,    17,   150,
+     127,   127,   117,   127,   127,   127,   127,   122,   127,   119,
+      65,    17,   127
   };
 
   const unsigned char
@@ -3066,13 +3115,14 @@ namespace yy {
      115,   116,   116,   117,   117,   118,   118,   119,   119,   119,
      119,   119,   119,   119,   119,   119,   119,   119,   119,   119,
      119,   119,   119,   119,   120,   121,   121,   121,   122,   122,
-     122,   122,   122,   122,   123,   123,   124,   125,   125,   125,
-     125,   125,   125,   125,   125,   125,   125,   125,   125,   125,
-     125,   125,   125,   125,   125,   125,   125,   125,   126,   127,
-     128,   128,   129,   130,   131,   131,   132,   133,   134,   135,
-     135,   136,   136,   136,   136,   137,   138,   139,   140,   141,
-     141,   141,   141,   142,   142,   143,   143,   144,   144,   145,
-     145,   147,   146,   148,   146,   149,   150,   151,   152
+     122,   123,   123,   123,   123,   123,   123,   124,   124,   125,
+     126,   126,   126,   126,   126,   126,   126,   126,   126,   126,
+     126,   126,   126,   126,   126,   126,   126,   126,   126,   127,
+     127,   127,   128,   129,   130,   130,   131,   132,   133,   133,
+     134,   135,   136,   137,   137,   138,   138,   138,   138,   139,
+     140,   141,   142,   143,   143,   143,   143,   144,   144,   145,
+     145,   146,   146,   147,   147,   149,   148,   150,   148,   151,
+     152,   153,   154
   };
 
   const unsigned char
@@ -3088,14 +3138,15 @@ namespace yy {
        2,     1,     1,     2,     2,     1,     2,     2,     1,     2,
        5,     3,     2,     1,     2,     3,     1,     3,     3,     3,
        3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     2,     1,     3,     1,     3,     4,     4,     6,
-       7,     6,     8,     9,     3,     1,     5,     1,     1,     1,
+       3,     3,     2,     1,     3,     1,     3,     4,     1,     1,
+       1,     4,     6,     7,     6,     8,     9,     3,     1,     5,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     2,     4,     2,     2,
-       2,     1,     1,     3,     3,     1,     2,     3,     5,     2,
-       1,     1,     1,     1,     1,     3,     3,     3,     3,     7,
-       4,     5,     2,     3,     3,     3,     3,     2,     1,     4,
-       6,     0,     7,     0,     9,     4,     4,     6,     2
+       1,     1,     1,     1,     1,     1,     1,     2,     4,     1,
+       1,     1,     2,     2,     2,     1,     1,     3,     3,     1,
+       2,     3,     5,     2,     1,     1,     1,     1,     1,     3,
+       3,     3,     3,     7,     4,     5,     2,     3,     3,     3,
+       3,     2,     1,     4,     6,     0,     7,     0,     9,     4,
+       4,     6,     2
   };
 
 
@@ -3126,14 +3177,14 @@ namespace yy {
   "INITIALIZER", "ATOM", "VALUE", "INTEGER_NUMBER", "NUMBER", "RULEREF",
   "NUMBER_RANGE", "LISTCONST", "EXPRESSION_LIST",
   "EXPRESSION_LIST_NO_COMMA", "EXPRESSION", "BRACKET_EXPRESSION",
-  "FUNCTION_SYNTAX", "RULE_SYNTAX", "DUMPSPEC_LIST", "DUMPSPEC",
-  "STATEMENT", "ASSERT_SYNTAX", "ASSURE_SYNTAX", "DIEDIE_SYNTAX",
-  "IMPOSSIBLE_SYNTAX", "DEBUG_SYNTAX", "DEBUG_ATOM_LIST", "PRINT_SYNTAX",
-  "UPDATE_SYNTAX", "CASE_SYNTAX", "CASE_LABEL_LIST", "CASE_LABEL",
-  "CASE_LABEL_DEFAULT", "CASE_LABEL_NUMBER", "CASE_LABEL_IDENT",
-  "CASE_LABEL_STRING", "CALL_SYNTAX", "SEQ_SYNTAX", "PAR_SYNTAX",
-  "STATEMENTS", "IFTHENELSE", "LET_SYNTAX", "$@1", "$@2", "PUSH_SYNTAX",
-  "POP_SYNTAX", "FORALL_SYNTAX", "ITERATE_SYNTAX", YY_NULLPTR
+  "FUNCTION_SYNTAX", "RULE_STMT", "RULE_SYNTAX", "DUMPSPEC_LIST",
+  "DUMPSPEC", "SIMPLE_STMT", "STATEMENT", "ASSERT_SYNTAX", "ASSURE_SYNTAX",
+  "DIEDIE_SYNTAX", "IMPOSSIBLE_SYNTAX", "DEBUG_SYNTAX", "DEBUG_ATOM_LIST",
+  "PRINT_SYNTAX", "UPDATE_SYNTAX", "CASE_SYNTAX", "CASE_LABEL_LIST",
+  "CASE_LABEL", "CASE_LABEL_DEFAULT", "CASE_LABEL_NUMBER",
+  "CASE_LABEL_IDENT", "CASE_LABEL_STRING", "CALL_SYNTAX", "SEQ_SYNTAX",
+  "PAR_SYNTAX", "STATEMENTS", "IFTHENELSE", "LET_SYNTAX", "$@1", "$@2",
+  "PUSH_SYNTAX", "POP_SYNTAX", "FORALL_SYNTAX", "ITERATE_SYNTAX", YY_NULLPTR
   };
 
 #if YYDEBUG
@@ -3151,13 +3202,14 @@ namespace yy {
      535,   546,   547,   551,   552,   554,   558,   565,   567,   569,
      571,   573,   575,   577,   579,   581,   583,   585,   587,   589,
      591,   593,   595,   597,   600,   603,   604,   605,   618,   619,
-     622,   626,   630,   634,   640,   641,   647,   652,   653,   654,
-     655,   656,   657,   658,   659,   660,   661,   662,   663,   664,
-     665,   666,   667,   668,   669,   670,   671,   672,   675,   677,
-     680,   681,   691,   694,   697,   698,   700,   703,   713,   718,
-     722,   728,   729,   730,   731,   734,   739,   744,   749,   754,
-     755,   756,   757,   760,   763,   768,   771,   776,   777,   780,
-     783,   789,   788,   802,   801,   816,   826,   837,   842
+     620,   627,   628,   631,   635,   639,   643,   649,   650,   656,
+     661,   662,   663,   664,   665,   666,   667,   668,   669,   670,
+     671,   672,   673,   674,   675,   676,   677,   678,   679,   682,
+     683,   684,   687,   689,   692,   693,   703,   706,   709,   710,
+     712,   715,   725,   730,   734,   740,   741,   742,   743,   746,
+     751,   756,   761,   766,   767,   768,   769,   772,   775,   780,
+     783,   788,   789,   792,   795,   801,   800,   814,   813,   828,
+     838,   849,   854
   };
 
   // Print the state stack on the debug stream.
@@ -3192,8 +3244,8 @@ namespace yy {
 
 
 } // yy
-#line 3196 "GrammarParser.cpp" // lalr1.cc:1167
-#line 846 "../../src/GrammarParser.yy" // lalr1.cc:1168
+#line 3248 "GrammarParser.cpp" // lalr1.cc:1167
+#line 858 "../../src/GrammarParser.yy" // lalr1.cc:1168
 
 
 void yy::casmi_parser::error

--- a/src/various/GrammarParser.tab.h
+++ b/src/various/GrammarParser.tab.h
@@ -302,7 +302,9 @@ namespace yy {
       char dummy2[sizeof(AstListNode*)];
 
       // BODY_ELEMENT
+      // RULE_STMT
       // RULE_SYNTAX
+      // SIMPLE_STMT
       // STATEMENT
       // IMPOSSIBLE_SYNTAX
       char dummy3[sizeof(AstNode*)];
@@ -1267,8 +1269,8 @@ namespace yy {
     enum
     {
       yyeof_ = 0,
-      yylast_ = 955,     ///< Last index in yytable_.
-      yynnts_ = 66,  ///< Number of nonterminal symbols.
+      yylast_ = 1013,     ///< Last index in yytable_.
+      yynnts_ = 68,  ///< Number of nonterminal symbols.
       yyfinal_ = 5, ///< Termination state number.
       yyterror_ = 1,
       yyerrcode_ = 256,
@@ -1363,14 +1365,16 @@ namespace yy {
         break;
 
       case 90: // BODY_ELEMENTS
-      case 144: // STATEMENTS
+      case 146: // STATEMENTS
         value.copy< AstListNode* > (other.value);
         break;
 
       case 91: // BODY_ELEMENT
-      case 122: // RULE_SYNTAX
-      case 125: // STATEMENT
-      case 129: // IMPOSSIBLE_SYNTAX
+      case 122: // RULE_STMT
+      case 123: // RULE_SYNTAX
+      case 126: // SIMPLE_STMT
+      case 127: // STATEMENT
+      case 131: // IMPOSSIBLE_SYNTAX
         value.copy< AstNode* > (other.value);
         break;
 
@@ -1384,15 +1388,15 @@ namespace yy {
         value.copy< BaseFunctionAtom* > (other.value);
         break;
 
-      case 141: // CALL_SYNTAX
+      case 143: // CALL_SYNTAX
         value.copy< CallNode* > (other.value);
         break;
 
-      case 134: // CASE_SYNTAX
+      case 136: // CASE_SYNTAX
         value.copy< CaseNode* > (other.value);
         break;
 
-      case 128: // DIEDIE_SYNTAX
+      case 130: // DIEDIE_SYNTAX
         value.copy< DiedieNode* > (other.value);
         break;
 
@@ -1410,7 +1414,7 @@ namespace yy {
         value.copy< FLOATING_T > (other.value);
         break;
 
-      case 151: // FORALL_SYNTAX
+      case 153: // FORALL_SYNTAX
         value.copy< ForallNode* > (other.value);
         break;
 
@@ -1423,7 +1427,7 @@ namespace yy {
         value.copy< INTEGER_T > (other.value);
         break;
 
-      case 145: // IFTHENELSE
+      case 147: // IFTHENELSE
         value.copy< IfThenElseNode* > (other.value);
         break;
 
@@ -1435,20 +1439,20 @@ namespace yy {
         value.copy< IntegerAtom* > (other.value);
         break;
 
-      case 146: // LET_SYNTAX
+      case 148: // LET_SYNTAX
         value.copy< LetNode* > (other.value);
         break;
 
-      case 150: // POP_SYNTAX
+      case 152: // POP_SYNTAX
         value.copy< PopNode* > (other.value);
         break;
 
-      case 130: // DEBUG_SYNTAX
-      case 132: // PRINT_SYNTAX
+      case 132: // DEBUG_SYNTAX
+      case 134: // PRINT_SYNTAX
         value.copy< PrintNode* > (other.value);
         break;
 
-      case 149: // PUSH_SYNTAX
+      case 151: // PUSH_SYNTAX
         value.copy< PushNode* > (other.value);
         break;
 
@@ -1461,15 +1465,15 @@ namespace yy {
         value.copy< Type* > (other.value);
         break;
 
-      case 126: // ASSERT_SYNTAX
-      case 127: // ASSURE_SYNTAX
-      case 142: // SEQ_SYNTAX
-      case 143: // PAR_SYNTAX
-      case 152: // ITERATE_SYNTAX
+      case 128: // ASSERT_SYNTAX
+      case 129: // ASSURE_SYNTAX
+      case 144: // SEQ_SYNTAX
+      case 145: // PAR_SYNTAX
+      case 154: // ITERATE_SYNTAX
         value.copy< UnaryNode* > (other.value);
         break;
 
-      case 133: // UPDATE_SYNTAX
+      case 135: // UPDATE_SYNTAX
         value.copy< UpdateNode* > (other.value);
         break;
 
@@ -1477,11 +1481,11 @@ namespace yy {
         value.copy< rational_t > (other.value);
         break;
 
-      case 136: // CASE_LABEL
-      case 137: // CASE_LABEL_DEFAULT
-      case 138: // CASE_LABEL_NUMBER
-      case 139: // CASE_LABEL_IDENT
-      case 140: // CASE_LABEL_STRING
+      case 138: // CASE_LABEL
+      case 139: // CASE_LABEL_DEFAULT
+      case 140: // CASE_LABEL_NUMBER
+      case 141: // CASE_LABEL_IDENT
+      case 142: // CASE_LABEL_STRING
         value.copy< std::pair<AtomNode*, AstNode*> > (other.value);
         break;
 
@@ -1489,7 +1493,7 @@ namespace yy {
         value.copy< std::pair<ExpressionBase*, ExpressionBase*> > (other.value);
         break;
 
-      case 124: // DUMPSPEC
+      case 125: // DUMPSPEC
         value.copy< std::pair<std::string, std::vector<std::string>> > (other.value);
         break;
 
@@ -1503,7 +1507,7 @@ namespace yy {
         value.copy< std::string > (other.value);
         break;
 
-      case 131: // DEBUG_ATOM_LIST
+      case 133: // DEBUG_ATOM_LIST
         value.copy< std::vector<ExpressionBase*> > (other.value);
         break;
 
@@ -1520,7 +1524,7 @@ namespace yy {
         value.copy< std::vector<Type*> > (other.value);
         break;
 
-      case 135: // CASE_LABEL_LIST
+      case 137: // CASE_LABEL_LIST
         value.copy< std::vector<std::pair<AtomNode*, AstNode*>> > (other.value);
         break;
 
@@ -1529,7 +1533,7 @@ namespace yy {
         value.copy< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > (other.value);
         break;
 
-      case 123: // DUMPSPEC_LIST
+      case 124: // DUMPSPEC_LIST
         value.copy< std::vector<std::pair<std::string, std::vector<std::string>>> > (other.value);
         break;
 
@@ -1560,14 +1564,16 @@ namespace yy {
         break;
 
       case 90: // BODY_ELEMENTS
-      case 144: // STATEMENTS
+      case 146: // STATEMENTS
         value.copy< AstListNode* > (v);
         break;
 
       case 91: // BODY_ELEMENT
-      case 122: // RULE_SYNTAX
-      case 125: // STATEMENT
-      case 129: // IMPOSSIBLE_SYNTAX
+      case 122: // RULE_STMT
+      case 123: // RULE_SYNTAX
+      case 126: // SIMPLE_STMT
+      case 127: // STATEMENT
+      case 131: // IMPOSSIBLE_SYNTAX
         value.copy< AstNode* > (v);
         break;
 
@@ -1581,15 +1587,15 @@ namespace yy {
         value.copy< BaseFunctionAtom* > (v);
         break;
 
-      case 141: // CALL_SYNTAX
+      case 143: // CALL_SYNTAX
         value.copy< CallNode* > (v);
         break;
 
-      case 134: // CASE_SYNTAX
+      case 136: // CASE_SYNTAX
         value.copy< CaseNode* > (v);
         break;
 
-      case 128: // DIEDIE_SYNTAX
+      case 130: // DIEDIE_SYNTAX
         value.copy< DiedieNode* > (v);
         break;
 
@@ -1607,7 +1613,7 @@ namespace yy {
         value.copy< FLOATING_T > (v);
         break;
 
-      case 151: // FORALL_SYNTAX
+      case 153: // FORALL_SYNTAX
         value.copy< ForallNode* > (v);
         break;
 
@@ -1620,7 +1626,7 @@ namespace yy {
         value.copy< INTEGER_T > (v);
         break;
 
-      case 145: // IFTHENELSE
+      case 147: // IFTHENELSE
         value.copy< IfThenElseNode* > (v);
         break;
 
@@ -1632,20 +1638,20 @@ namespace yy {
         value.copy< IntegerAtom* > (v);
         break;
 
-      case 146: // LET_SYNTAX
+      case 148: // LET_SYNTAX
         value.copy< LetNode* > (v);
         break;
 
-      case 150: // POP_SYNTAX
+      case 152: // POP_SYNTAX
         value.copy< PopNode* > (v);
         break;
 
-      case 130: // DEBUG_SYNTAX
-      case 132: // PRINT_SYNTAX
+      case 132: // DEBUG_SYNTAX
+      case 134: // PRINT_SYNTAX
         value.copy< PrintNode* > (v);
         break;
 
-      case 149: // PUSH_SYNTAX
+      case 151: // PUSH_SYNTAX
         value.copy< PushNode* > (v);
         break;
 
@@ -1658,15 +1664,15 @@ namespace yy {
         value.copy< Type* > (v);
         break;
 
-      case 126: // ASSERT_SYNTAX
-      case 127: // ASSURE_SYNTAX
-      case 142: // SEQ_SYNTAX
-      case 143: // PAR_SYNTAX
-      case 152: // ITERATE_SYNTAX
+      case 128: // ASSERT_SYNTAX
+      case 129: // ASSURE_SYNTAX
+      case 144: // SEQ_SYNTAX
+      case 145: // PAR_SYNTAX
+      case 154: // ITERATE_SYNTAX
         value.copy< UnaryNode* > (v);
         break;
 
-      case 133: // UPDATE_SYNTAX
+      case 135: // UPDATE_SYNTAX
         value.copy< UpdateNode* > (v);
         break;
 
@@ -1674,11 +1680,11 @@ namespace yy {
         value.copy< rational_t > (v);
         break;
 
-      case 136: // CASE_LABEL
-      case 137: // CASE_LABEL_DEFAULT
-      case 138: // CASE_LABEL_NUMBER
-      case 139: // CASE_LABEL_IDENT
-      case 140: // CASE_LABEL_STRING
+      case 138: // CASE_LABEL
+      case 139: // CASE_LABEL_DEFAULT
+      case 140: // CASE_LABEL_NUMBER
+      case 141: // CASE_LABEL_IDENT
+      case 142: // CASE_LABEL_STRING
         value.copy< std::pair<AtomNode*, AstNode*> > (v);
         break;
 
@@ -1686,7 +1692,7 @@ namespace yy {
         value.copy< std::pair<ExpressionBase*, ExpressionBase*> > (v);
         break;
 
-      case 124: // DUMPSPEC
+      case 125: // DUMPSPEC
         value.copy< std::pair<std::string, std::vector<std::string>> > (v);
         break;
 
@@ -1700,7 +1706,7 @@ namespace yy {
         value.copy< std::string > (v);
         break;
 
-      case 131: // DEBUG_ATOM_LIST
+      case 133: // DEBUG_ATOM_LIST
         value.copy< std::vector<ExpressionBase*> > (v);
         break;
 
@@ -1717,7 +1723,7 @@ namespace yy {
         value.copy< std::vector<Type*> > (v);
         break;
 
-      case 135: // CASE_LABEL_LIST
+      case 137: // CASE_LABEL_LIST
         value.copy< std::vector<std::pair<AtomNode*, AstNode*>> > (v);
         break;
 
@@ -1726,7 +1732,7 @@ namespace yy {
         value.copy< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > (v);
         break;
 
-      case 123: // DUMPSPEC_LIST
+      case 124: // DUMPSPEC_LIST
         value.copy< std::vector<std::pair<std::string, std::vector<std::string>>> > (v);
         break;
 
@@ -2047,14 +2053,16 @@ namespace yy {
         break;
 
       case 90: // BODY_ELEMENTS
-      case 144: // STATEMENTS
+      case 146: // STATEMENTS
         value.template destroy< AstListNode* > ();
         break;
 
       case 91: // BODY_ELEMENT
-      case 122: // RULE_SYNTAX
-      case 125: // STATEMENT
-      case 129: // IMPOSSIBLE_SYNTAX
+      case 122: // RULE_STMT
+      case 123: // RULE_SYNTAX
+      case 126: // SIMPLE_STMT
+      case 127: // STATEMENT
+      case 131: // IMPOSSIBLE_SYNTAX
         value.template destroy< AstNode* > ();
         break;
 
@@ -2068,15 +2076,15 @@ namespace yy {
         value.template destroy< BaseFunctionAtom* > ();
         break;
 
-      case 141: // CALL_SYNTAX
+      case 143: // CALL_SYNTAX
         value.template destroy< CallNode* > ();
         break;
 
-      case 134: // CASE_SYNTAX
+      case 136: // CASE_SYNTAX
         value.template destroy< CaseNode* > ();
         break;
 
-      case 128: // DIEDIE_SYNTAX
+      case 130: // DIEDIE_SYNTAX
         value.template destroy< DiedieNode* > ();
         break;
 
@@ -2094,7 +2102,7 @@ namespace yy {
         value.template destroy< FLOATING_T > ();
         break;
 
-      case 151: // FORALL_SYNTAX
+      case 153: // FORALL_SYNTAX
         value.template destroy< ForallNode* > ();
         break;
 
@@ -2107,7 +2115,7 @@ namespace yy {
         value.template destroy< INTEGER_T > ();
         break;
 
-      case 145: // IFTHENELSE
+      case 147: // IFTHENELSE
         value.template destroy< IfThenElseNode* > ();
         break;
 
@@ -2119,20 +2127,20 @@ namespace yy {
         value.template destroy< IntegerAtom* > ();
         break;
 
-      case 146: // LET_SYNTAX
+      case 148: // LET_SYNTAX
         value.template destroy< LetNode* > ();
         break;
 
-      case 150: // POP_SYNTAX
+      case 152: // POP_SYNTAX
         value.template destroy< PopNode* > ();
         break;
 
-      case 130: // DEBUG_SYNTAX
-      case 132: // PRINT_SYNTAX
+      case 132: // DEBUG_SYNTAX
+      case 134: // PRINT_SYNTAX
         value.template destroy< PrintNode* > ();
         break;
 
-      case 149: // PUSH_SYNTAX
+      case 151: // PUSH_SYNTAX
         value.template destroy< PushNode* > ();
         break;
 
@@ -2145,15 +2153,15 @@ namespace yy {
         value.template destroy< Type* > ();
         break;
 
-      case 126: // ASSERT_SYNTAX
-      case 127: // ASSURE_SYNTAX
-      case 142: // SEQ_SYNTAX
-      case 143: // PAR_SYNTAX
-      case 152: // ITERATE_SYNTAX
+      case 128: // ASSERT_SYNTAX
+      case 129: // ASSURE_SYNTAX
+      case 144: // SEQ_SYNTAX
+      case 145: // PAR_SYNTAX
+      case 154: // ITERATE_SYNTAX
         value.template destroy< UnaryNode* > ();
         break;
 
-      case 133: // UPDATE_SYNTAX
+      case 135: // UPDATE_SYNTAX
         value.template destroy< UpdateNode* > ();
         break;
 
@@ -2161,11 +2169,11 @@ namespace yy {
         value.template destroy< rational_t > ();
         break;
 
-      case 136: // CASE_LABEL
-      case 137: // CASE_LABEL_DEFAULT
-      case 138: // CASE_LABEL_NUMBER
-      case 139: // CASE_LABEL_IDENT
-      case 140: // CASE_LABEL_STRING
+      case 138: // CASE_LABEL
+      case 139: // CASE_LABEL_DEFAULT
+      case 140: // CASE_LABEL_NUMBER
+      case 141: // CASE_LABEL_IDENT
+      case 142: // CASE_LABEL_STRING
         value.template destroy< std::pair<AtomNode*, AstNode*> > ();
         break;
 
@@ -2173,7 +2181,7 @@ namespace yy {
         value.template destroy< std::pair<ExpressionBase*, ExpressionBase*> > ();
         break;
 
-      case 124: // DUMPSPEC
+      case 125: // DUMPSPEC
         value.template destroy< std::pair<std::string, std::vector<std::string>> > ();
         break;
 
@@ -2187,7 +2195,7 @@ namespace yy {
         value.template destroy< std::string > ();
         break;
 
-      case 131: // DEBUG_ATOM_LIST
+      case 133: // DEBUG_ATOM_LIST
         value.template destroy< std::vector<ExpressionBase*> > ();
         break;
 
@@ -2204,7 +2212,7 @@ namespace yy {
         value.template destroy< std::vector<Type*> > ();
         break;
 
-      case 135: // CASE_LABEL_LIST
+      case 137: // CASE_LABEL_LIST
         value.template destroy< std::vector<std::pair<AtomNode*, AstNode*>> > ();
         break;
 
@@ -2213,7 +2221,7 @@ namespace yy {
         value.template destroy< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > ();
         break;
 
-      case 123: // DUMPSPEC_LIST
+      case 124: // DUMPSPEC_LIST
         value.template destroy< std::vector<std::pair<std::string, std::vector<std::string>>> > ();
         break;
 
@@ -2250,14 +2258,16 @@ namespace yy {
         break;
 
       case 90: // BODY_ELEMENTS
-      case 144: // STATEMENTS
+      case 146: // STATEMENTS
         value.move< AstListNode* > (s.value);
         break;
 
       case 91: // BODY_ELEMENT
-      case 122: // RULE_SYNTAX
-      case 125: // STATEMENT
-      case 129: // IMPOSSIBLE_SYNTAX
+      case 122: // RULE_STMT
+      case 123: // RULE_SYNTAX
+      case 126: // SIMPLE_STMT
+      case 127: // STATEMENT
+      case 131: // IMPOSSIBLE_SYNTAX
         value.move< AstNode* > (s.value);
         break;
 
@@ -2271,15 +2281,15 @@ namespace yy {
         value.move< BaseFunctionAtom* > (s.value);
         break;
 
-      case 141: // CALL_SYNTAX
+      case 143: // CALL_SYNTAX
         value.move< CallNode* > (s.value);
         break;
 
-      case 134: // CASE_SYNTAX
+      case 136: // CASE_SYNTAX
         value.move< CaseNode* > (s.value);
         break;
 
-      case 128: // DIEDIE_SYNTAX
+      case 130: // DIEDIE_SYNTAX
         value.move< DiedieNode* > (s.value);
         break;
 
@@ -2297,7 +2307,7 @@ namespace yy {
         value.move< FLOATING_T > (s.value);
         break;
 
-      case 151: // FORALL_SYNTAX
+      case 153: // FORALL_SYNTAX
         value.move< ForallNode* > (s.value);
         break;
 
@@ -2310,7 +2320,7 @@ namespace yy {
         value.move< INTEGER_T > (s.value);
         break;
 
-      case 145: // IFTHENELSE
+      case 147: // IFTHENELSE
         value.move< IfThenElseNode* > (s.value);
         break;
 
@@ -2322,20 +2332,20 @@ namespace yy {
         value.move< IntegerAtom* > (s.value);
         break;
 
-      case 146: // LET_SYNTAX
+      case 148: // LET_SYNTAX
         value.move< LetNode* > (s.value);
         break;
 
-      case 150: // POP_SYNTAX
+      case 152: // POP_SYNTAX
         value.move< PopNode* > (s.value);
         break;
 
-      case 130: // DEBUG_SYNTAX
-      case 132: // PRINT_SYNTAX
+      case 132: // DEBUG_SYNTAX
+      case 134: // PRINT_SYNTAX
         value.move< PrintNode* > (s.value);
         break;
 
-      case 149: // PUSH_SYNTAX
+      case 151: // PUSH_SYNTAX
         value.move< PushNode* > (s.value);
         break;
 
@@ -2348,15 +2358,15 @@ namespace yy {
         value.move< Type* > (s.value);
         break;
 
-      case 126: // ASSERT_SYNTAX
-      case 127: // ASSURE_SYNTAX
-      case 142: // SEQ_SYNTAX
-      case 143: // PAR_SYNTAX
-      case 152: // ITERATE_SYNTAX
+      case 128: // ASSERT_SYNTAX
+      case 129: // ASSURE_SYNTAX
+      case 144: // SEQ_SYNTAX
+      case 145: // PAR_SYNTAX
+      case 154: // ITERATE_SYNTAX
         value.move< UnaryNode* > (s.value);
         break;
 
-      case 133: // UPDATE_SYNTAX
+      case 135: // UPDATE_SYNTAX
         value.move< UpdateNode* > (s.value);
         break;
 
@@ -2364,11 +2374,11 @@ namespace yy {
         value.move< rational_t > (s.value);
         break;
 
-      case 136: // CASE_LABEL
-      case 137: // CASE_LABEL_DEFAULT
-      case 138: // CASE_LABEL_NUMBER
-      case 139: // CASE_LABEL_IDENT
-      case 140: // CASE_LABEL_STRING
+      case 138: // CASE_LABEL
+      case 139: // CASE_LABEL_DEFAULT
+      case 140: // CASE_LABEL_NUMBER
+      case 141: // CASE_LABEL_IDENT
+      case 142: // CASE_LABEL_STRING
         value.move< std::pair<AtomNode*, AstNode*> > (s.value);
         break;
 
@@ -2376,7 +2386,7 @@ namespace yy {
         value.move< std::pair<ExpressionBase*, ExpressionBase*> > (s.value);
         break;
 
-      case 124: // DUMPSPEC
+      case 125: // DUMPSPEC
         value.move< std::pair<std::string, std::vector<std::string>> > (s.value);
         break;
 
@@ -2390,7 +2400,7 @@ namespace yy {
         value.move< std::string > (s.value);
         break;
 
-      case 131: // DEBUG_ATOM_LIST
+      case 133: // DEBUG_ATOM_LIST
         value.move< std::vector<ExpressionBase*> > (s.value);
         break;
 
@@ -2407,7 +2417,7 @@ namespace yy {
         value.move< std::vector<Type*> > (s.value);
         break;
 
-      case 135: // CASE_LABEL_LIST
+      case 137: // CASE_LABEL_LIST
         value.move< std::vector<std::pair<AtomNode*, AstNode*>> > (s.value);
         break;
 
@@ -2416,7 +2426,7 @@ namespace yy {
         value.move< std::vector<std::pair<ExpressionBase*, ExpressionBase*>>* > (s.value);
         break;
 
-      case 123: // DUMPSPEC_LIST
+      case 124: // DUMPSPEC_LIST
         value.move< std::vector<std::pair<std::string, std::vector<std::string>>> > (s.value);
         break;
 
@@ -3006,7 +3016,7 @@ namespace yy {
 
 
 } // yy
-#line 3010 "GrammarParser.tab.h" // lalr1.cc:377
+#line 3020 "GrammarParser.tab.h" // lalr1.cc:377
 
 
 


### PR DESCRIPTION
Added two non-terminals, SIMPLE_STMT is required to avoid a bunch of reduce/reduce conflicts.
- Fix wrong AST creation for rules with a single statement but without SEQ or PAR,
- Embed the statement within a PAR block

Fixes #21
