### PR TITLE
"symbolic()" syntax changes 

### DIFF
--- a/src/Symbols.cpp
+++ b/src/Symbols.cpp
@@ -128,8 +128,8 @@ static void built_in_check_bitargs
 //  }
 
 Builtin built_ins[] =
-{ { "symbolic"
-  , Builtin::Id::SYMBOLIC
+{ { "isSymbolic"
+  , Builtin::Id::IS_SYMBOLIC
   , { TypeType::BOOLEAN }
   , { { TypeType::UNKNOWN
       }

--- a/src/Symbols.h
+++ b/src/Symbols.h
@@ -52,7 +52,7 @@ public:
     
     enum class Id
     // general built-ins
-    { SYMBOLIC
+    { IS_SYMBOLIC
 
     // tuple and list built-ins
     , NTH

--- a/src/execute/ExecutionPassBase.cpp
+++ b/src/execute/ExecutionPassBase.cpp
@@ -577,7 +577,7 @@ namespace builtins
         }
     }
 
-    static const value_t symbolic(const value_t& arg)
+    static const value_t issymbolic(const value_t& arg)
     {
         if (arg.is_symbolic() && !arg.value.sym->list) {
             return value_t(true);
@@ -751,8 +751,8 @@ const value_t ExecutionPassBase::visit_builtin_atom(BuiltinAtom *atom,
         return builtins::asfloating(arguments[0]);
     case Builtin::Id::AS_RATIONAL:
         return builtins::asrational(arguments[0]);
-    case Builtin::Id::SYMBOLIC:
-        return builtins::symbolic(arguments[0]);
+    case Builtin::Id::IS_SYMBOLIC:
+        return builtins::issymbolic(arguments[0]);
     default:
         FAILURE();
     }


### PR DESCRIPTION
- Renamed builtin "symbolic()" to "isSymbolic()"

Closes #29
