### PR TITLE
Visitor and Walker

### DIFF
--- a/src/Visitor.h
+++ b/src/Visitor.h
@@ -256,10 +256,11 @@ class AstWalker
         // we must walk the expression before walking update->func because it
         // sets the list of arguments and we do not want the update->expr_ to
         // overwrite the value_list
-        walk_function_atom( node->func );
 
-        const auto argumentValues
-            = evaluateExpressions( node->func->arguments );
+        auto argumentValues = evaluateExpressions( node->func->arguments );
+
+        visitor.visit_function_atom( node->func, argumentValues );
+
         visitor.visit_update( node, argumentValues, expr );
     }
 


### PR DESCRIPTION
* fixed visitor and walker bug which was introduced due to a redundant
  visit_expression_* call, because the walk update function called the
  walk_function_atom twice
  - see bug #61 

Please review and merge afterwards!
Please close the related issue as well.
