### PR TITLE
Drop variable referencing

### DIFF
--- a/src/analyze/SymbolResolverPass.cpp
+++ b/src/analyze/SymbolResolverPass.cpp
@@ -192,12 +192,6 @@ void SymbolResolveVisitor::visit( ReferenceAtom& node )
                 node.setReference( symbol.definition() );
                 break;
             }
-            case CallExpression::TargetType::VARIABLE:
-            {
-                node.setReferenceType( ReferenceAtom::ReferenceType::VARIABLE );
-                node.setReference( symbol.definition() );
-                break;
-            }
             default:
             {
                 m_log.error( { node.identifier()->sourceLocation() },

--- a/src/analyze/TypeInferencePass.cpp
+++ b/src/analyze/TypeInferencePass.cpp
@@ -277,11 +277,6 @@ void TypeInferenceVisitor::visit( ReferenceAtom& node )
             node.setType( type );
             break;
         }
-        case ReferenceAtom::ReferenceType::VARIABLE:
-        {
-            // TODO
-            break;
-        }
         default:
         {
             assert( !" unknown reference type! " );

--- a/src/ast/Expression.cpp
+++ b/src/ast/Expression.cpp
@@ -194,10 +194,6 @@ std::string CallExpression::targetTypeString( const TargetType targetType )
         {
             return "constant";
         }
-        case TargetType::VARIABLE:
-        {
-            return "variable";
-        }
         case TargetType::SELF:
         {
             return "self";

--- a/src/ast/Expression.h
+++ b/src/ast/Expression.h
@@ -90,7 +90,6 @@ namespace libcasm_fe
                 DERIVED,
                 BUILTIN,
                 RULE,
-                VARIABLE,
                 UNKNOWN
             };
 

--- a/src/execute/NumericExecutionPass.cpp
+++ b/src/execute/NumericExecutionPass.cpp
@@ -637,11 +637,6 @@ void ExecutionVisitor::visit( IndirectCallExpression& node )
             m_frameStack.pop();
             break;
         }
-        case ReferenceAtom::ReferenceType::VARIABLE:
-        {
-            atom->reference()->accept( *this );
-            break;
-        }
         case ReferenceAtom::ReferenceType::UNKNOWN:
         {
             assert( !"cannot call an unknown target" );

--- a/src/transform/AstToCasmIRPass.cpp
+++ b/src/transform/AstToCasmIRPass.cpp
@@ -334,11 +334,6 @@ void AstToCasmIRVisitor::visit( ReferenceAtom& node )
                     rule );
             break;
         }
-        case ReferenceAtom::ReferenceType::VARIABLE:
-        {
-            m_log.error( { node.sourceLocation() }, "TODO" );
-            break;
-        }
         case ReferenceAtom::ReferenceType::UNKNOWN:
         {
             m_log.error( { node.sourceLocation() }, "TODO" );


### PR DESCRIPTION
This doesn't make sense, because variables are always const and thus can always
be passed by reference.