### PR TITLE
TypeCheckPass: Drop all the typing related code

### DIFF
--- a/src/analyze/TypeInferencePass.cpp
+++ b/src/analyze/TypeInferencePass.cpp
@@ -152,8 +152,10 @@ void TypeInferenceVisitor::visit( FunctionDefinition& node )
         return;
     }
 
+    node.returnType()->accept( *this );
     assert( node.returnType()->type() && "return type must be specified" );
 
+    node.argumentTypes()->accept( *this );
     std::vector< libcasm_ir::Type::Ptr > argTypeList;
     argTypeList.reserve( node.argumentTypes()->size() );
     for( const auto& argumentType : *node.argumentTypes() )
@@ -168,8 +170,9 @@ void TypeInferenceVisitor::visit( FunctionDefinition& node )
 
     auto& returnType = *node.returnType()->type();
     m_typeIDs[ node.defaultValue().get() ].emplace( returnType.id() );
+    node.defaultValue()->accept( *this );
 
-    RecursiveVisitor::visit( node );
+    node.initializers()->accept( *this );
 }
 
 void TypeInferenceVisitor::visit( DerivedDefinition& node )
@@ -180,8 +183,10 @@ void TypeInferenceVisitor::visit( DerivedDefinition& node )
         return;
     }
 
+    node.returnType()->accept( *this );
     assert( node.returnType()->type() && "return type must be specified" );
 
+    node.arguments()->accept( *this );
     std::vector< libcasm_ir::Type::Ptr > argTypeList;
     argTypeList.reserve( node.arguments()->size() );
     for( const auto& argument : *node.arguments() )
@@ -196,8 +201,7 @@ void TypeInferenceVisitor::visit( DerivedDefinition& node )
 
     auto& returnType = *node.returnType()->type();
     m_typeIDs[ node.expression().get() ].emplace( returnType.id() );
-
-    RecursiveVisitor::visit( node );
+    node.expression()->accept( *this );
 
     if( node.expression()->type() )
     {
@@ -226,8 +230,10 @@ void TypeInferenceVisitor::visit( RuleDefinition& node )
         return;
     }
 
+    node.returnType()->accept( *this );
     assert( node.returnType()->type() && "return type must be specified" );
 
+    node.arguments()->accept( *this );
     std::vector< libcasm_ir::Type::Ptr > argTypeList;
     argTypeList.reserve( node.arguments()->size() );
     for( const auto& argument : *node.arguments() )
@@ -240,7 +246,7 @@ void TypeInferenceVisitor::visit( RuleDefinition& node )
         node.returnType()->type(), argTypeList );
     node.setType( type );
 
-    RecursiveVisitor::visit( node );
+    node.rule()->accept( *this );
 }
 
 void TypeInferenceVisitor::visit( UndefAtom& node )


### PR DESCRIPTION
Typing should only be done in the TypeInferencePass. This removes a huge amount
of duplicated code and also makes it possible to implement the `Type Definition`
feature properly. So that it also works for enums and so on.

The relative path resolving will also be added to the type inference, so that
relative enum contants can be used anywhere and not only where it has been
hardcoded (case, let).

2 additional test cases are failing (indirect call tests). This will be fixed in another pull request by properly implementing the indirect call resolving in the type inference pass.