### PR TITLE
ConsistencyCheckPass: Don't treat functions like a function call in UpdateRule

### DIFF
--- a/src/analyze/ConsistencyCheckPass.cpp
+++ b/src/analyze/ConsistencyCheckPass.cpp
@@ -242,7 +242,9 @@ void ConsistencyCheckVisitor::visit( DirectCallExpression& node )
 
 void ConsistencyCheckVisitor::visit( UpdateRule& node )
 {
-    RecursiveVisitor::visit( node );
+    // don't visit the function directly, as it would be treated like a function call
+
+    node.expression()->accept( *this );
 
     const auto& func = node.function();
     if( func->targetType() != CallExpression::TargetType::FUNCTION )
@@ -254,6 +256,8 @@ void ConsistencyCheckVisitor::visit( UpdateRule& node )
             Code::UpdateRuleFunctionSymbolIsInvalid );
         return;
     }
+
+    func->arguments()->accept( *this );
 
     const auto& def = func->targetDefinition()->ptr< FunctionDefinition >();
 


### PR DESCRIPTION
Functions in calls and updates must be handled differently. This fixes an error when updating out functions (see https://github.com/casm-lang/libcasm-tc/blob/master/test/rule/update/update_out_function.casm).

Added some additional tests to avoid regressions, see https://github.com/casm-lang/libcasm-tc/pull/19.

🍰
