### PR TITLE
TypeInferencePass: fix inference for type domains with definitions

### DIFF
--- a/src/analyze/TypeInferencePass.cpp
+++ b/src/analyze/TypeInferencePass.cpp
@@ -501,6 +501,23 @@ void TypeInferenceVisitor::visit( DirectCallExpression& node )
         }
         case CallExpression::TargetType::TYPE_DOMAIN:
         {
+            if( node.type() )
+            {
+                break;
+            }
+
+            assert( node.arguments()->size() == 0 );
+
+            // if the type domain has FE definition use this type!
+            const auto& definition = node.targetDefinition();
+            if( definition )
+            {
+                definition->accept( *this );
+                assert( definition->type()->arguments().size() == 0 );
+                node.setType( definition->type() );
+                break;
+            }
+
             try
             {
                 const auto& typeDomain = TypeInfo::instance().getType( identifier->path() );


### PR DESCRIPTION
* see: https://github.com/casm-lang/libcasm-fe/pull/129/files/2a338c7f45550dfb534da784150e5c779253bb78#r168010396
* related to PR #129 
