### PR TITLE
Cleanups in type inference

### DIFF
--- a/src/analyze/TypeInferencePass.cpp
+++ b/src/analyze/TypeInferencePass.cpp
@@ -1620,15 +1620,6 @@ void TypeInferenceVisitor::visit( UpdateRule& node )
 
     node.expression()->accept( *this );
 
-    if( func.targetType() == CallExpression::TargetType::BUILTIN )
-    {
-        m_log.error(
-            { func.sourceLocation() },
-            "performing update rule on built-in '" + func.identifier()->path() + "' is not allowed",
-            Code::TypeInferenceUpdateRuleFunctionIsBuiltin );
-        return;
-    }
-
     assignment(
         node,
         func,


### PR DESCRIPTION
* Function default values is always set (see parser)
* Update target is already checked in the consistency checker

Tests were adjusted in https://github.com/casm-lang/libcasm-tc/pull/34