### PR TITLE
[TypeInferencePass] Drop forall rule universe is integer check

### DIFF
--- a/src/Codes.h
+++ b/src/Codes.h
@@ -257,7 +257,6 @@ namespace libcasm_fe
         TypeInferenceForallUniverseHasNoType = 0x1014,
         TypeInferenceForallRuleTypeMismatch = 0x1024,
         TypeInferenceForallRuleInvalidConditionType = 0x1025,
-        TypeInferenceForallRuleInvalidUniverseType = 0x1026,
 
         TypeInferenceInvalidConditionalExpressionCondition = 0x1005,
         TypeInferenceInvalidConditionalExpressionPaths = 0x1006

--- a/src/analyze/TypeInferencePass.cpp
+++ b/src/analyze/TypeInferencePass.cpp
@@ -1484,19 +1484,6 @@ void TypeInferenceVisitor::visit( ForallRule& node )
                 Code::TypeInferenceForallRuleTypeMismatch );
         }
     }
-
-    if( node.universe()->type() )
-    {
-        const auto& universeType = node.universe()->type();
-        if( universeType->isInteger() )
-        {
-            m_log.error(
-                { node.universe()->sourceLocation() },
-                node.description() + " has an invalid universe type '" +
-                    universeType->description() + "'",
-                Code::TypeInferenceForallRuleInvalidUniverseType );
-        }
-    }
 }
 
 void TypeInferenceVisitor::visit( ChooseRule& node )


### PR DESCRIPTION
Checking if the specified forall universe makes sense isn't the job of the type inference.