### PR TITLE
[SymbolResolverPass] Make it possible to use using definitions with IR type in calls

### DIFF
--- a/src/analyze/SymbolResolverPass.cpp
+++ b/src/analyze/SymbolResolverPass.cpp
@@ -286,6 +286,13 @@ void SymbolResolveVisitor::visit( DirectCallExpression& node )
                 node.setTargetType( DirectCallExpression::TargetType::TYPE_DOMAIN );
                 break;
             }
+            case Node::ID::USING_DEFINITION:
+            {
+                // if the using definition points to an IR type then the alias resolving fails,
+                // because there is no definition which can be resolved, and we end up here
+                node.setTargetType( DirectCallExpression::TargetType::TYPE_DOMAIN );
+                break;
+            }
             default:
             {
                 m_log.error(
@@ -457,7 +464,14 @@ Definition::Ptr SymbolResolveVisitor::resolveIfAlias( const Definition::Ptr& def
 
     const auto usingDefinition = std::static_pointer_cast< UsingDefinition >( definition );
     const auto symbol = m_symboltable.findSymbol( *usingDefinition->type()->name() );
-    return resolveIfAlias( symbol );  // resolve again, the symbol may be another alias
+    if( symbol )
+    {
+        return resolveIfAlias( symbol );  // resolve again, the symbol may be another alias
+    }
+    else
+    {
+        return definition;
+    }
 }
 
 void SymbolResolverPass::usage( libpass::PassUsage& pu )


### PR DESCRIPTION
Using definitions with IR types cannot be resolved, because there is no target definition. Thus we end up with an using definition in the direct call which needs to be treated like a type-call.

Tests were added in https://github.com/casm-lang/libcasm-tc/pull/46

This also fixes the crash in https://github.com/casm-lang/libcasm-tc/pull/44 which was caused by this bug.