### PR TITLE
GrammarParserHelperTest: fixed include to make test runnable again

### DIFF
--- a/etc/test/GrammarParserHelperTest.cpp
+++ b/etc/test/GrammarParserHelperTest.cpp
@@ -43,7 +43,7 @@
 
 #include "main.h"
 
-#include <libcasm-fe/GrammarParserHelper>
+#include "../../src/GrammarParserHelper.h"
 
 using namespace libcasm_fe;
 


### PR DESCRIPTION
* see: https://github.com/casm-lang/libcasm-fe/commit/88dccbffa18582de81704b56cc0f12917a27be05