### PR TITLE
[PropertyResolverPass] Don't mark `self` as pure

### DIFF
--- a/src/analyze/PropertyResolverPass.cpp
+++ b/src/analyze/PropertyResolverPass.cpp
@@ -194,7 +194,6 @@ void PropertyResolverVisitor::visit( DirectCallExpression& node )
         case DirectCallExpression::TargetType::SELF:
         {
             callProperties.set( libcasm_ir::Property::SIDE_EFFECT_FREE );
-            callProperties.set( libcasm_ir::Property::PURE );
             break;
         }
         case DirectCallExpression::TargetType::UNKNOWN:


### PR DESCRIPTION
`self` is only side-effect free

Tests were added in https://github.com/casm-lang/libcasm-tc/pull/52