### PR TITLE
SymbolRegistrationPass: Fix a compiler error caused by a wrong "const"

### DIFF
--- a/src/analyze/SymbolRegistrationPass.cpp
+++ b/src/analyze/SymbolRegistrationPass.cpp
@@ -82,7 +82,7 @@ class SymbolRegistrationVisitor final : public RecursiveVisitor
     void visit( UsingDefinition& node ) override;
 
   private:
-    void registerSymbol( const Definition& node );
+    void registerSymbol( Definition& node );
 
   private:
     libcasm_fe::Logger& m_log;
@@ -171,7 +171,7 @@ void SymbolRegistrationVisitor::visit( UsingDefinition& node )
     RecursiveVisitor::visit( node );
 }
 
-void SymbolRegistrationVisitor::registerSymbol( const Definition& node )
+void SymbolRegistrationVisitor::registerSymbol( Definition& node )
 {
     const auto& name = node.identifier()->name();
 


### PR DESCRIPTION
Introduced in commit 54dbac9fec368332e5f94231b5bfd96c8f58bb86