### PR TITLE
ConsistencyCheckPass: Remove the type enforcement from RelationType

### DIFF
--- a/src/analyze/ConsistencyCheckPass.cpp
+++ b/src/analyze/ConsistencyCheckPass.cpp
@@ -456,22 +456,7 @@ void ConsistencyCheckVisitor::visit( FixedSizedType& node )
 void ConsistencyCheckVisitor::visit( RelationType& node )
 {
     RecursiveVisitor::visit( node );
-
-    if( node.type() )
-    {
-        if( node.type()->kind() == IR::Type::Kind::RULE_REFERENCE )
-        {
-            verifyHasTypeOfKind( node, IR::Type::Kind::RULE_REFERENCE );
-        }
-        else
-        {
-            verifyHasTypeOfKind( node, IR::Type::Kind::RELATION );
-        }
-    }
-    else
-    {
-        verifyHasType( node );
-    }
+    verifyHasType( node );
 }
 
 void ConsistencyCheckVisitor::verifyHasType( const TypedNode& node )


### PR DESCRIPTION
It is possible that the resulting type is a function reference type.

See also d493389c076c17e661225149a634635ae5665daa