### PR TITLE
Some additional type inference cleanups

### DIFF
--- a/src/Codes.h
+++ b/src/Codes.h
@@ -185,8 +185,6 @@ namespace libcasm_fe
         TypeInferenceFoundMultipleResultTypes = 0x1101,
         TypeInferenceFoundNoArgumentType = 0x1102,
 
-        TypeInferenceInvalidUpdateRuleFunctionType = 0x1203,
-        TypeInferenceInvalidUpdateRuleExpressionType = 0x1204,
         TypeInferenceUpdateRuleTypesMismatch = 0x1205,
         TypeInferenceUpdateRuleFunctionIsBuiltin = 0x1206,
 
@@ -238,8 +236,6 @@ namespace libcasm_fe
         TypeInferenceInvalidChooseRuleVariableTypeMismatch = 0x1009
 
         ,
-        TypeInferenceInvalidVariableBindingVariableType = 0x1010,
-        TypeInferenceInvalidVariableBindingExpressionType = 0x1011,
         TypeInferenceInvalidVariableBindingTypeMismatch = 0x1012,
 
         TypeInferenceRangeLiteralTypeMismatch = 0x1600,


### PR DESCRIPTION
* Don't show "could not infer type" errors in assignment()
* Remove explicit setType() of undef expressions in assignment
* Filter annotations by tuple kind before using them for type inference of tuple literals

Tests were adjusted in https://github.com/casm-lang/libcasm-tc/pull/67