### PR TITLE
[PropertyResolverPass] Always mark a choose expression as in-pure

### DIFF
--- a/src/analyze/PropertyResolverPass.cpp
+++ b/src/analyze/PropertyResolverPass.cpp
@@ -321,7 +321,9 @@ void PropertyResolverVisitor::visit( ChooseExpression& node )
 {
     RecursiveVisitor::visit( node );
 
-    node.setProperties( node.universe()->properties() * node.expression()->properties() );
+    auto properties = node.universe()->properties() * node.expression()->properties();
+    properties.unset( libcasm_ir::Property::PURE );  // randomness is in-pure
+    node.setProperties( properties );
 }
 
 void PropertyResolverVisitor::visit( UniversalQuantifierExpression& node )


### PR DESCRIPTION
Pure functions (in case of CASM: deriveds) are only allowed to depend on the
input values and thus random number generators cannot be used in pure
expressions.

Tests were added in https://github.com/casm-lang/libcasm-tc/pull/71