### PR TITLE
Get rid of FunctionDefinition::UID and reuse function evaluation code

### DIFF
--- a/src/analyze/ConsistencyCheckPass.cpp
+++ b/src/analyze/ConsistencyCheckPass.cpp
@@ -167,7 +167,7 @@ void ConsistencyCheckVisitor::visit( FunctionDefinition& node )
     node.defaultValue()->accept( *this );
     node.attributes()->accept( *this );
 
-    if( node.uid() == FunctionDefinition::UID::PROGRAM )
+    if( node.isProgram() )
     {
         m_initDefinitionFound = true;
     }

--- a/src/ast/Definition.cpp
+++ b/src/ast/Definition.cpp
@@ -148,8 +148,7 @@ FunctionDefinition::FunctionDefinition(
     }
     else
     {
-        static auto uidGenerator = static_cast< std::size_t >( UID::OTHER );
-        m_uid = static_cast< UID >( uidGenerator++ );
+        m_uid = UID::OTHER;
     }
 
     setProperty( libcasm_ir::Property::SIDE_EFFECT_FREE );

--- a/src/ast/Definition.cpp
+++ b/src/ast/Definition.cpp
@@ -132,31 +132,14 @@ FunctionDefinition::FunctionDefinition(
 , m_symbolic( false )
 , m_initializers( std::make_shared< NodeList< UpdateRule > >() )
 , m_defaultValue( std::make_shared< UndefLiteral >() )
+, m_isProgram( identifier->name() == "program" )
 {
-    const auto& name = identifier->name();
-    if( name == "self" )
-    {
-        m_uid = UID::SELF;
-    }
-    else if( name == "program" )
-    {
-        m_uid = UID::PROGRAM;
-    }
-    else if( name == "result" )
-    {
-        m_uid = UID::RESULT;
-    }
-    else
-    {
-        m_uid = UID::OTHER;
-    }
-
     setProperty( libcasm_ir::Property::SIDE_EFFECT_FREE );
 }
 
-FunctionDefinition::UID FunctionDefinition::uid( void ) const
+bool FunctionDefinition::isProgram( void ) const
 {
-    return m_uid;
+    return m_isProgram;
 }
 
 const Types::Ptr& FunctionDefinition::argumentTypes( void ) const

--- a/src/ast/Definition.h
+++ b/src/ast/Definition.h
@@ -130,14 +130,6 @@ namespace libcasm_fe
                 STATIC
             };
 
-            enum class UID
-            {
-                SELF = 1,
-                PROGRAM = 2,
-                RESULT = 3,
-                OTHER
-            };
-
             static std::string toString( const Classification classification );
 
           public:
@@ -148,7 +140,7 @@ namespace libcasm_fe
                 const Types::Ptr& argumentTypes,
                 const Type::Ptr& returnType );
 
-            UID uid() const;
+            bool isProgram( void ) const;
 
             const Types::Ptr& argumentTypes( void ) const;
             const Type::Ptr& returnType( void ) const;
@@ -175,7 +167,7 @@ namespace libcasm_fe
             u1 m_symbolic;
             NodeList< UpdateRule >::Ptr m_initializers;
             Expression::Ptr m_defaultValue;
-            UID m_uid;
+            const bool m_isProgram;
         };
 
         class DerivedDefinition final : public Definition
@@ -269,18 +261,6 @@ namespace libcasm_fe
             const Type::Ptr m_type;
         };
     }
-}
-
-namespace std
-{
-    template <>
-    struct hash< libcasm_fe::Ast::FunctionDefinition::UID >
-    {
-        std::size_t operator()( libcasm_fe::Ast::FunctionDefinition::UID uid ) const
-        {
-            return static_cast< std::size_t >( uid );
-        }
-    };
 }
 
 #endif  // _LIBCASM_FE_DEFINITION_H_

--- a/src/execute/LocationRegistry.h
+++ b/src/execute/LocationRegistry.h
@@ -105,7 +105,6 @@ class LocationRegistry
         explicit Location( const LocationData* data )
         : m_data( data )
         {
-            assert( m_data != nullptr );
         }
 
         const Function& function() const
@@ -116,6 +115,19 @@ class LocationRegistry
         const Arguments& arguments() const
         {
             return m_data->second;
+        }
+
+        bool isValid() const
+        {
+            return m_data != nullptr;
+        }
+
+        /**
+         * Is used to indicate an invalid location.
+         */
+        static constexpr Location invalid()
+        {
+            return Location( nullptr );
         }
 
         friend struct LocationHash;

--- a/src/execute/NumericExecutionPass.cpp
+++ b/src/execute/NumericExecutionPass.cpp
@@ -242,7 +242,7 @@ void Storage::fireUpdateSet( ExecutionUpdateSet* updateSet )
 
 void Storage::set( const Location& location, const Value& value )
 {
-    if( location.function()->uid() == FunctionDefinition::UID::PROGRAM )
+    if( location.function()->isProgram() )
     {
         m_programState.set( location, value );
     }
@@ -254,7 +254,7 @@ void Storage::set( const Location& location, const Value& value )
 
 void Storage::remove( const Location& location )
 {
-    if( location.function()->uid() == FunctionDefinition::UID::PROGRAM )
+    if( location.function()->isProgram() )
     {
         m_programState.remove( location );
     }
@@ -266,7 +266,7 @@ void Storage::remove( const Location& location )
 
 std::experimental::optional< Storage::Value > Storage::get( const Location& location ) const
 {
-    if( location.function()->uid() == FunctionDefinition::UID::PROGRAM )
+    if( location.function()->isProgram() )
     {
         return m_programState.get( location );
     }


### PR DESCRIPTION
* Use the memory address of function definitions as UIDs instead of inventing another one
* Use existing function evaluation code to get the update location
    * Reduces code duplication
    * Makes it possible to update "method functions" (better name required ..) when the other bits are implemented