### PR TITLE
NumericExecutionPass: fixed incorrect lookup behavior

### DIFF
--- a/src/execute/NumericExecutionPass.cpp
+++ b/src/execute/NumericExecutionPass.cpp
@@ -669,8 +669,11 @@ void ExecutionVisitor::visit( DirectCallExpression& node )
         case DirectCallExpression::TargetType::RULE:
         {
             const auto& definition = node.targetDefinition();
+            const auto evaluateUpdateLocation = m_evaluateUpdateLocation;
+            m_evaluateUpdateLocation = false;
             m_frameStack.push(
                 makeFrame( &node, definition.get(), definition->maximumNumberOfLocals() ) );
+            m_evaluateUpdateLocation = evaluateUpdateLocation;
             definition->accept( *this );
             m_frameStack.pop();
             break;


### PR DESCRIPTION
* argument evaluation always has to be done in function lookup mode
* fixes casm-lang/casm#78
