### PR TITLE
Introduce Update-Set epochs and make use of it in Iterate and While rule evaluation

### DIFF
--- a/etc/test/updateset/UpdateSetTest.cpp
+++ b/etc/test/updateset/UpdateSetTest.cpp
@@ -130,6 +130,21 @@ TEST( UpdateSetTest, mergeUpdateSetsIntoEmptyUpdateSetsShouldSwapValues )
     EXPECT_EQ( 3, seqUpdateSet->size() );
 }
 
+TEST( UpdateSetTest, updateSetShouldBeEmptyAfterMergingItsUpdatesIntoAnotherUpdateSet )
+{
+    const auto updateSet1 =
+        std::unique_ptr< TestUpdateSet >( new SequentialUpdateSet< UpdateSetDetails >( 10UL ) );
+    updateSet1->add( 1UL, "1000" );
+
+    const auto updateSet2 = std::unique_ptr< TestUpdateSet >(
+        updateSet1->fork( TestUpdateSet::Semantics::Sequential, 10UL ) );
+    updateSet2->add( 1UL, "2000" );
+
+    updateSet2->merge();
+
+    EXPECT_TRUE( updateSet2->empty() );
+}
+
 TEST(
     UpdateSetTest,
     mergeSequentialUpdateSetsIntoParallelShouldNotThrowWhenOverwritingSameLocationWithSameValue )

--- a/src/execute/UpdateSet.h
+++ b/src/execute/UpdateSet.h
@@ -301,6 +301,8 @@ class UpdateSet
     /**
      * Merges all updates of the current update-set into the update-set \a other
      *
+     * @post The current update-set is cleared.
+     *
      * @param other The update-set which should receive the updates (must not
      *        be nullptr)
      *
@@ -324,6 +326,8 @@ class UpdateSet
             {
                 other->add( it.key(), it.value() );
             }
+
+            this->clear();
         }
     }
 


### PR DESCRIPTION
Each time a new update is added to the update-set the epoch is increased.
Therefore, we can use the epoch to check if the nested rule produced any updates, just by checking if the epoch changed.

This replaces the ugly parallel update-set workaround used in Iterate and While rule evaluation with a much cleaner concept. The fixpoint behaviour of both rules is directly reflected by: `do ... while( previousEpoch != updateSet->epoch() )`

Please note that commit b9dec1aa3fdbbf0597ec9b4657fccd0fb3bd150c is somehow unrelated to the epoch changes. But given that the commit only affects a few lines I have included it in this PR.
