### PR TITLE
Bugfix/specification name

### DIFF
--- a/src/Specification.cpp
+++ b/src/Specification.cpp
@@ -60,7 +60,7 @@ const std::string& Specification::fileExtension( void )
 Specification::Specification( void )
 : m_asmType( AsmType::SYNCHRONOUS )
 , m_name()
-, m_location( "", "", "", "", "" )
+, m_location()
 , m_header()
 , m_definitions()
 , m_spans( std::make_shared< Ast::Spans >() )
@@ -88,12 +88,12 @@ const std::string& Specification::name( void ) const
     return m_name;
 }
 
-void Specification::setLocation( const libstdhl::Standard::RFC3986::URI& location )
+void Specification::setLocation( const libstdhl::Standard::RFC3986::URI::Ptr& location )
 {
     m_location = location;
 }
 
-const libstdhl::Standard::RFC3986::URI& Specification::location( void ) const
+const libstdhl::Standard::RFC3986::URI::Ptr& Specification::location( void ) const
 {
     return m_location;
 }

--- a/src/Specification.cpp
+++ b/src/Specification.cpp
@@ -60,6 +60,7 @@ const std::string& Specification::fileExtension( void )
 Specification::Specification( void )
 : m_asmType( AsmType::SYNCHRONOUS )
 , m_name()
+, m_location( "", "", "", "", "" )
 , m_header()
 , m_definitions()
 , m_spans( std::make_shared< Ast::Spans >() )
@@ -85,6 +86,16 @@ void Specification::setName( const std::string& name )
 const std::string& Specification::name( void ) const
 {
     return m_name;
+}
+
+void Specification::setLocation( const libstdhl::Standard::RFC3986::URI& location )
+{
+    m_location = location;
+}
+
+const libstdhl::Standard::RFC3986::URI& Specification::location( void ) const
+{
+    return m_location;
 }
 
 void Specification::setHeader( const Ast::HeaderDefinition::Ptr& header )

--- a/src/Specification.cpp
+++ b/src/Specification.cpp
@@ -78,24 +78,42 @@ Specification::AsmType Specification::asmType( void ) const
     return m_asmType;
 }
 
-void Specification::setName( const std::string& name )
-{
-    m_name = name;
-}
-
-const std::string& Specification::name( void ) const
-{
-    return m_name;
-}
-
 void Specification::setLocation( const libstdhl::Standard::RFC3986::URI::Ptr& location )
 {
     m_location = location;
+
+    if( m_location->scheme() != "file" )
+    {
+        throw std::invalid_argument(
+            "unsupported scheme '" + m_location->scheme() + "' scheme found" );
+    }
+
+    //
+    // <spec-path> ::= [ <file-path> / ] <file-name> [ .<file-extension> ]
+    //
+
+    const auto fileName = m_location->path();
+    auto lastSlashPos = fileName.find_last_of( '/' );
+    auto lastPointPos = fileName.rfind( "." );
+
+    // if <file-path> has no slash set to start position, otherwise increment by one
+    lastSlashPos = ( lastSlashPos == std::string::npos ) ? 0 : lastSlashPos + 1;
+
+    // if <spec-path> has no point set to end position, otherwise decrement by one
+    lastPointPos = ( lastPointPos == std::string::npos ) ? fileName.size() - 1 : lastPointPos - 1;
+
+    // extract sub-string with start position and length (delta) characters and set member
+    m_name = fileName.substr( lastSlashPos, lastPointPos - lastSlashPos );
 }
 
 const libstdhl::Standard::RFC3986::URI::Ptr& Specification::location( void ) const
 {
     return m_location;
+}
+
+const std::string& Specification::name( void ) const
+{
+    return m_name;
 }
 
 void Specification::setHeader( const Ast::HeaderDefinition::Ptr& header )

--- a/src/Specification.h
+++ b/src/Specification.h
@@ -79,8 +79,8 @@ namespace libcasm_fe
         void setName( const std::string& name );
         const std::string& name( void ) const;
 
-        void setLocation( const libstdhl::Standard::RFC3986::URI& location );
-        const libstdhl::Standard::RFC3986::URI& location( void ) const;
+        void setLocation( const libstdhl::Standard::RFC3986::URI::Ptr& location );
+        const libstdhl::Standard::RFC3986::URI::Ptr& location( void ) const;
 
         void setHeader( const Ast::HeaderDefinition::Ptr& header );
 
@@ -101,7 +101,7 @@ namespace libcasm_fe
       private:
         AsmType m_asmType;
         std::string m_name;
-        libstdhl::Standard::RFC3986::URI m_location;
+        libstdhl::Standard::RFC3986::URI::Ptr m_location;
         Ast::HeaderDefinition::Ptr m_header;
         Ast::Definitions::Ptr m_definitions;
         Ast::Spans::Ptr m_spans;

--- a/src/Specification.h
+++ b/src/Specification.h
@@ -76,11 +76,11 @@ namespace libcasm_fe
         void setAsmType( const AsmType asmType );
         AsmType asmType( void ) const;
 
-        void setName( const std::string& name );
-        const std::string& name( void ) const;
-
         void setLocation( const libstdhl::Standard::RFC3986::URI::Ptr& location );
+
         const libstdhl::Standard::RFC3986::URI::Ptr& location( void ) const;
+
+        const std::string& name( void ) const;
 
         void setHeader( const Ast::HeaderDefinition::Ptr& header );
 

--- a/src/Specification.h
+++ b/src/Specification.h
@@ -53,6 +53,8 @@
 #include <libcasm-fe/ast/Rule>
 #include <libcasm-fe/ast/Span>
 
+#include <libstdhl/std/rfc3986>
+
 namespace libcasm_fe
 {
     class Specification
@@ -77,6 +79,9 @@ namespace libcasm_fe
         void setName( const std::string& name );
         const std::string& name( void ) const;
 
+        void setLocation( const libstdhl::Standard::RFC3986::URI& location );
+        const libstdhl::Standard::RFC3986::URI& location( void ) const;
+
         void setHeader( const Ast::HeaderDefinition::Ptr& header );
 
         const Ast::HeaderDefinition::Ptr& header( void ) const;
@@ -96,6 +101,7 @@ namespace libcasm_fe
       private:
         AsmType m_asmType;
         std::string m_name;
+        libstdhl::Standard::RFC3986::URI m_location;
         Ast::HeaderDefinition::Ptr m_header;
         Ast::Definitions::Ptr m_definitions;
         Ast::Spans::Ptr m_spans;

--- a/src/import/FileLoadingStrategy.cpp
+++ b/src/import/FileLoadingStrategy.cpp
@@ -67,7 +67,7 @@ libstdhl::Standard::RFC3986::URI FileLoadingStrategy::toURI(
     const Ast::IdentifierPath::Ptr& identifierPath ) const
 {
     return libstdhl::Standard::RFC3986::URI(
-        "file", "", toFileSystemPath( identifierPath ), "", "" );
+        "file", "/", toFileSystemPath( identifierPath ), "", "" );
 }
 
 libpass::LoadFilePass::Input::Ptr FileLoadingStrategy::loadSource(

--- a/src/import/LibraryLoaderPass.cpp
+++ b/src/import/LibraryLoaderPass.cpp
@@ -130,7 +130,7 @@ u1 LibraryLoaderPass::run( libpass::PassResult& pr )
     const auto data = pr.output< SourceToAstPass >();
     const auto specification = data->specification();
     const auto symboltable = specification->symboltable();
-    const auto specificationFileName = specification->location().path();
+    const auto specificationFileName = specification->location()->path();
 
     const auto projectResolverData = pr.output< ProjectResolverPass >();
     const auto project = projectResolverData->project();

--- a/src/import/LibraryLoaderPass.cpp
+++ b/src/import/LibraryLoaderPass.cpp
@@ -130,7 +130,7 @@ u1 LibraryLoaderPass::run( libpass::PassResult& pr )
     const auto data = pr.output< SourceToAstPass >();
     const auto specification = data->specification();
     const auto symboltable = specification->symboltable();
-    const auto specificationFileName = specification->name();
+    const auto specificationFileName = specification->location().path();
 
     const auto projectResolverData = pr.output< ProjectResolverPass >();
     const auto project = projectResolverData->project();

--- a/src/import/LibraryLoaderPass.cpp
+++ b/src/import/LibraryLoaderPass.cpp
@@ -176,8 +176,7 @@ u1 LibraryLoaderPass::run( libpass::PassResult& pr )
     assert( loader.specificationRepository() != nullptr );
     assert( loader.specificationRepository()->project() != nullptr );
 
-    std::string uri = "file://" + specificationFileName;
-    loader.specificationRepository()->store( uri, specification );
+    loader.specificationRepository()->store( specification->location()->toString(), specification );
 
     LibraryLoaderVisitor visitor( log, *symboltable, loader );
     specification->definitions()->accept( visitor );

--- a/src/import/PathLoadingStrategy.cpp
+++ b/src/import/PathLoadingStrategy.cpp
@@ -67,7 +67,7 @@ libstdhl::Standard::RFC3986::URI PathLoadingStrategy::toURI(
     const Ast::IdentifierPath::Ptr& identifierPath ) const
 {
     return libstdhl::Standard::RFC3986::URI(
-        "file", "", toFileSystemPath( identifierPath ), "", "" );
+        "file", "/", toFileSystemPath( identifierPath ), "", "" );
 }
 
 libpass::LoadFilePass::Input::Ptr PathLoadingStrategy::loadSource(

--- a/src/import/SpecificationMergerPass.cpp
+++ b/src/import/SpecificationMergerPass.cpp
@@ -95,6 +95,7 @@ u1 SpecificationMergerPass::run( libpass::PassResult& pr )
 
     mergedSpecification->setAsmType( parsedSpecification->asmType() );
     mergedSpecification->setName( parsedSpecification->name() );
+    mergedSpecification->setLocation( parsedSpecification->location() );
     mergedSpecification->setHeader( parsedSpecification->header() );
     mergedSpecification->setSpans( parsedSpecification->spans() );
     mergedSpecification->setSymboltable( parsedSpecification->symboltable() );

--- a/src/import/SpecificationMergerPass.cpp
+++ b/src/import/SpecificationMergerPass.cpp
@@ -94,7 +94,6 @@ u1 SpecificationMergerPass::run( libpass::PassResult& pr )
     const auto mergedSpecification = std::make_shared< Specification >();
 
     mergedSpecification->setAsmType( parsedSpecification->asmType() );
-    mergedSpecification->setName( parsedSpecification->name() );
     mergedSpecification->setLocation( parsedSpecification->location() );
     mergedSpecification->setHeader( parsedSpecification->header() );
     mergedSpecification->setSpans( parsedSpecification->spans() );

--- a/src/transform/SourceToAstPass.cpp
+++ b/src/transform/SourceToAstPass.cpp
@@ -83,8 +83,24 @@ u1 SourceToAstPass::run( libpass::PassResult& pr )
     Lexer lexer( log, specificationFileStream, std::cout );
     lexer.setFileName( specificationFileName );
 
+    auto specificationName = specificationFileName;
+    const auto lastSlashPos = specificationName.find_last_of( '/' );
+    const auto lastPointPos = specificationName.rfind( "." );
+
+    if( lastSlashPos != std::string::npos )
+    {
+        specificationName =
+            specificationName.substr( lastSlashPos + 1, lastPointPos - lastSlashPos - 1 );
+    }
+    else
+    {
+        specificationName = specificationName.substr( 0, lastPointPos );
+    }
+
     const auto specification = std::make_shared< Specification >();
-    specification->setName( specificationFileName );
+    specification->setName( specificationName );
+    specification->setLocation(
+        libstdhl::Standard::RFC3986::URI( "file", "", specificationFileName, "", "" ) );
 
     Parser parser( log, lexer, *specification );
     parser.set_debug_level( m_debug );

--- a/src/transform/SourceToAstPass.cpp
+++ b/src/transform/SourceToAstPass.cpp
@@ -83,31 +83,16 @@ u1 SourceToAstPass::run( libpass::PassResult& pr )
     Lexer lexer( log, specificationFileStream, std::cout );
     lexer.setFileName( specificationFileName );
 
-    auto specificationName = specificationFileName;
-    const auto lastSlashPos = specificationName.find_last_of( '/' );
-    const auto lastPointPos = specificationName.rfind( "." );
-
-    if( lastSlashPos != std::string::npos )
-    {
-        specificationName =
-            specificationName.substr( lastSlashPos + 1, lastPointPos - lastSlashPos - 1 );
-    }
-    else
-    {
-        specificationName = specificationName.substr( 0, lastPointPos );
-    }
-
     const auto specification = std::make_shared< Specification >();
-    specification->setName( specificationName );
     specification->setLocation( std::make_shared< libstdhl::Standard::RFC3986::URI >(
-        "file", "", specificationFileName, "", "" ) );
+        "file", "/", specificationFileName, "", "" ) );
 
     Parser parser( log, lexer, *specification );
     parser.set_debug_level( m_debug );
 
     if( ( parser.parse() != 0 ) or not specification or ( log.errors() > 0 ) )
     {
-        log.error( "could not parse '" + specification->name() + "'" );
+        log.error( "could not parse '" + specification->location()->toString() + "'" );
         return false;
     }
 

--- a/src/transform/SourceToAstPass.cpp
+++ b/src/transform/SourceToAstPass.cpp
@@ -99,8 +99,8 @@ u1 SourceToAstPass::run( libpass::PassResult& pr )
 
     const auto specification = std::make_shared< Specification >();
     specification->setName( specificationName );
-    specification->setLocation(
-        libstdhl::Standard::RFC3986::URI( "file", "", specificationFileName, "", "" ) );
+    specification->setLocation( std::make_shared< libstdhl::Standard::RFC3986::URI >(
+        "file", "", specificationFileName, "", "" ) );
 
     Parser parser( log, lexer, *specification );
     parser.set_debug_level( m_debug );

--- a/src/transform/SourceToAstPass.h
+++ b/src/transform/SourceToAstPass.h
@@ -52,6 +52,8 @@
 #include <libpass/PassResult>
 #include <libpass/PassUsage>
 
+#include <libstdhl/std/rfc3986>
+
 /**
    @brief    TODO
 


### PR DESCRIPTION
* use specification location (URI) as source information 
* provides ability for later non-file-based loading 
* improves `import` loading
* fixes incorrect handling of `AstDumpDotPass`and the creation of a proper output pass handling
