### PR TITLE
GrammarParser: Require Bison 3.2

### DIFF
--- a/src/GrammarParser.y
+++ b/src/GrammarParser.y
@@ -43,7 +43,7 @@
 //
 
 %skeleton "lalr1.cc"
-%require "3.0"
+%require "3.2"
 //%debug
 
 %defines

--- a/src/various/stack.hh
+++ b/src/various/stack.hh
@@ -1,8 +1,0 @@
-// A Bison parser, made by GNU Bison 3.5.
-
-// Starting with Bison 3.2, this file is useless: the structure it
-// used to define is now defined with the parser itself.
-//
-// To get rid of this file:
-// 1. add '%require "3.2"' (or newer) to your grammar file
-// 2. remove references to this file from your build system.


### PR DESCRIPTION
And drop `stack.hh` because it's not required anymore by Bison >= 3.2