### PR TITLE
SymbolResolverPass: Fix incorrect local function registration for local rule

### DIFF
--- a/src/analyze/SymbolResolverPass.cpp
+++ b/src/analyze/SymbolResolverPass.cpp
@@ -523,12 +523,7 @@ void SymbolResolveVisitor::visit( LetRule& node )
 
 void SymbolResolveVisitor::visit( LocalRule& node )
 {
-    for( const auto& function : *node.localFunctions() )
-    {
-        pushSymbol( function );
-        function->accept( *this );
-        popSymbol( function );
-    }
+    node.localFunctions()->accept( *this );
 
     pushSymbols< FunctionDefinition >( node.localFunctions() );
     node.rule()->accept( *this );


### PR DESCRIPTION
Registering (pushing) the local function during initialization of itself allows to use itself during initialization, i.e. x = { x }, which is incorrect.

This incorrect code was added because the target of the update rules need to be resolved, but this isn't required anymore thanks to https://github.com/casm-lang/libcasm-fe/pull/199.

Tests were added in https://github.com/casm-lang/libcasm-tc/pull/88