### PR TITLE
Better update conflict errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library( ${PROJECT}-cpp OBJECT
   execute/HashMapBase.cpp
   execute/ReferenceConstant.cpp
   execute/Frame.cpp
+  execute/RuntimeException.cpp
 
   import/FileLoadingStrategy.cpp
   import/PathLoadingStrategy.cpp
@@ -199,6 +200,7 @@ ecm_generate_headers( ${PROJECT}_EXECUTE_HEADERS_CPP
     RobinHoodHashMap
     Stack
     UpdateSet
+    RuntimeException
   PREFIX
     ${PROJECT}/execute
   RELATIVE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library( ${PROJECT}-cpp OBJECT
   execute/ReferenceConstant.cpp
   execute/Frame.cpp
   execute/RuntimeException.cpp
+  execute/UpdateException.cpp
 
   import/FileLoadingStrategy.cpp
   import/PathLoadingStrategy.cpp
@@ -201,6 +202,7 @@ ecm_generate_headers( ${PROJECT}_EXECUTE_HEADERS_CPP
     Stack
     UpdateSet
     RuntimeException
+    UpdateException
   PREFIX
     ${PROJECT}/execute
   RELATIVE

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -46,60 +46,32 @@
 
 using namespace libcasm_fe;
 
-ErrorCodeException::ErrorCodeException( const std::string& message, Code errorCode )
-: ErrorCodeException( libstdhl::SourceLocation(), message, errorCode )
+Exception::Exception( const std::string& message )
+: libcasm_fe::Exception( message, Code::Unspecified )
 {
 }
 
-ErrorCodeException::ErrorCodeException(
-    const libstdhl::SourceLocation& location, const std::string& message, Code errorCode )
-: ErrorCodeException( location, message, {}, errorCode )
+Exception::Exception( const std::string& message, Code errorCode )
+: libcasm_fe::Exception( {}, message, errorCode )
 {
 }
 
-ErrorCodeException::ErrorCodeException(
-    const libstdhl::SourceLocation& location,
-    const std::string& message,
-    const std::vector< std::string >& backtrace,
-    Code errorCode )
-: Exception( message )
-, m_locations( { location } )
-, m_backtrace( backtrace )
-, m_errorCode( errorCode )
-{
-}
-
-ErrorCodeException::ErrorCodeException(
+Exception::Exception(
     const std::vector< libstdhl::SourceLocation >& locations,
     const std::string& message,
     Code errorCode )
-: ErrorCodeException( locations, message, {}, errorCode )
-{
-}
-
-ErrorCodeException::ErrorCodeException(
-    const std::vector< libstdhl::SourceLocation >& locations,
-    const std::string& message,
-    const std::vector< std::string >& backtrace,
-    Code errorCode )
-: Exception( message )
+: libstdhl::Exception( message )
 , m_locations( locations )
-, m_backtrace( backtrace )
 , m_errorCode( errorCode )
 {
 }
 
-const std::vector< libstdhl::SourceLocation >& ErrorCodeException::locations( void ) const noexcept
+const std::vector< libstdhl::SourceLocation >& Exception::locations( void ) const noexcept
 {
     return m_locations;
 }
 
-const std::vector< std::string >& ErrorCodeException::backtrace( void ) const noexcept
-{
-    return m_backtrace;
-}
-
-Code ErrorCodeException::errorCode( void ) const noexcept
+Code Exception::errorCode( void ) const noexcept
 {
     return m_errorCode;
 }

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -112,10 +112,9 @@ void libcasm_fe::Logger::error(
     }
 }
 
-void libcasm_fe::Logger::error( const ErrorCodeException& exception )
+void libcasm_fe::Logger::error( const Exception& exception )
 {
     error( exception.locations(), exception.what(), exception.errorCode() );
-    info( "Backtrace:\n" + libstdhl::String::join( exception.backtrace(), "\n" ) );
 }
 
 void libcasm_fe::Logger::warning(

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -56,7 +56,7 @@
 
 namespace libcasm_fe
 {
-    class ErrorCodeException;
+    class Exception;
 
     class Logger : public libpass::PassLogger
     {
@@ -68,7 +68,7 @@ namespace libcasm_fe
             const std::vector< libstdhl::SourceLocation >& locations,
             const std::string& message,
             Code errorCode = Code::Unspecified );
-        void error( const ErrorCodeException& exception );
+        void error( const Exception& exception );
 
         using libpass::PassLogger::warning;
         void warning(

--- a/src/execute/ExecutionVisitor.cpp
+++ b/src/execute/ExecutionVisitor.cpp
@@ -1754,6 +1754,7 @@ void AgentScheduler::collectUpdates( const std::vector< Agent >& agents )
                 "Conflict while collection updates from agents. Update '" + updateStrA +
                     "' produced by agent " + agentStrA + " clashed with update '" + updateStrB +
                     "' produced by agent " + agentStrB,
+                {},
                 { updateAsUpdateInfo( updateA ), updateAsUpdateInfo( updateB ) },
                 libcasm_fe::Code::UpdateSetMergeConflict );
         }

--- a/src/execute/ExecutionVisitor.cpp
+++ b/src/execute/ExecutionVisitor.cpp
@@ -44,12 +44,12 @@
 
 #include "ExecutionVisitor.h"
 
-#include <libcasm-fe/Exception>
 #include <libcasm-fe/Logger>
 #include <libcasm-fe/analyze/FrameSizeDeterminationPass>
 #include <libcasm-fe/ast/Expression>
 #include <libcasm-fe/ast/RecursiveVisitor>
 #include <libcasm-fe/ast/Rule>
+#include <libcasm-fe/execute/RuntimeException>
 #include <libcasm-fe/transform/SourceToAstPass>
 
 #include <libcasm-ir/Exception>
@@ -396,7 +396,7 @@ void ExecutionVisitor::visit( InvariantDefinition& node )
     if( not result.defined() )
     {
         throw RuntimeException(
-            node.expression()->sourceLocation(),
+            { node.expression()->sourceLocation() },
             "result must be true or false but was undefined",
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::InvariantDefinitionInvalidExpression );
@@ -404,7 +404,7 @@ void ExecutionVisitor::visit( InvariantDefinition& node )
     else if( result.value() == false )
     {
         throw RuntimeException(
-            node.sourceLocation(),
+            { node.sourceLocation() },
             "invariant '" + node.identifier()->name() + "' violated",
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::InvariantDefinitionInvariantViolated );
@@ -585,7 +585,7 @@ void ExecutionVisitor::visit( MethodCallExpression& node )
             if( not object.defined() )
             {
                 throw RuntimeException(
-                    node.object()->sourceLocation(),
+                    { node.object()->sourceLocation() },
                     "cannot call a method of an undefined object",
                     m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
                     Code::Unspecified );
@@ -603,7 +603,7 @@ void ExecutionVisitor::visit( MethodCallExpression& node )
             if( not object.defined() )
             {
                 throw RuntimeException(
-                    node.object()->sourceLocation(),
+                    { node.object()->sourceLocation() },
                     "cannot call a method of an undefined object",
                     m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
                     Code::Unspecified );
@@ -673,7 +673,7 @@ void ExecutionVisitor::visit( IndirectCallExpression& node )
     if( not value.defined() )
     {
         throw RuntimeException(
-            node.expression()->sourceLocation(),
+            { node.expression()->sourceLocation() },
             "cannot call an undefined target",
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::Unspecified );
@@ -768,7 +768,7 @@ void ExecutionVisitor::visit( UnaryExpression& node )
     catch( const std::exception& e )
     {
         throw RuntimeException(
-            node.sourceLocation(),
+            { node.sourceLocation() },
             "unary expression has thrown an exception: " + std::string( e.what() ),
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::Unspecified );
@@ -790,7 +790,7 @@ void ExecutionVisitor::visit( BinaryExpression& node )
     catch( const IR::Exception& e )
     {
         throw RuntimeException(
-            node.sourceLocation(),
+            { node.sourceLocation() },
             "binary expression has thrown an exception: " + std::string( e.what() ),
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::Unspecified );
@@ -811,7 +811,7 @@ void ExecutionVisitor::visit( ConditionalExpression& node )
     if( not condition.defined() )
     {
         throw RuntimeException(
-            node.condition()->sourceLocation(),
+            { node.condition()->sourceLocation() },
             "condition must be true or false but was undefined",
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::ConditionalExpressionInvalidCondition );
@@ -834,7 +834,7 @@ void ExecutionVisitor::visit( ChooseExpression& node )
     if( not universe.defined() )
     {
         throw RuntimeException(
-            node.universe()->sourceLocation(),
+            { node.universe()->sourceLocation() },
             "universe must be defined",
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::ChooseExpressionInvalidUniverse );
@@ -862,7 +862,7 @@ void ExecutionVisitor::visit( UniversalQuantifierExpression& node )
     if( not universe.defined() )
     {
         throw RuntimeException(
-            node.universe()->sourceLocation(),
+            { node.universe()->sourceLocation() },
             "universe must be defined",
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::QuantifierExpressionInvalidUniverse );
@@ -911,7 +911,7 @@ void ExecutionVisitor::visit( ExistentialQuantifierExpression& node )
     if( not universe.defined() )
     {
         throw RuntimeException(
-            node.universe()->sourceLocation(),
+            { node.universe()->sourceLocation() },
             "universe must be defined",
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::QuantifierExpressionInvalidUniverse );
@@ -969,7 +969,7 @@ void ExecutionVisitor::visit( ConditionalRule& node )
     if( not condition.defined() )
     {
         throw RuntimeException(
-            node.condition()->sourceLocation(),
+            { node.condition()->sourceLocation() },
             "condition must be true or false but was undefined",
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::ConditionalRuleInvalidCondition );
@@ -1098,7 +1098,7 @@ void ExecutionVisitor::visit( ForallRule& node )
     if( not universe.defined() )
     {
         throw RuntimeException(
-            node.universe()->sourceLocation(),
+            { node.universe()->sourceLocation() },
             "universe must be defined",
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::ForallRuleInvalidUniverse );
@@ -1112,7 +1112,7 @@ void ExecutionVisitor::visit( ForallRule& node )
         if( not condition.defined() )
         {
             throw RuntimeException(
-                node.condition()->sourceLocation(),
+                { node.condition()->sourceLocation() },
                 "condition must be true or false but was undefined",
                 m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
                 Code::ForallRuleInvalidCondition );
@@ -1141,7 +1141,7 @@ void ExecutionVisitor::visit( ChooseRule& node )
     if( not universe.defined() )
     {
         throw RuntimeException(
-            node.universe()->sourceLocation(),
+            { node.universe()->sourceLocation() },
             "universe must be defined",
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::ChooseRuleInvalidUniverse );
@@ -1289,7 +1289,7 @@ void ExecutionVisitor::visit( WhileRule& node )
         if( not condition.defined() )
         {
             throw RuntimeException(
-                node.condition()->sourceLocation(),
+                { node.condition()->sourceLocation() },
                 "condition must be true or false but was undefined",
                 m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
                 Code::WhileRuleInvalidCondition );
@@ -1410,7 +1410,7 @@ void ExecutionVisitor::invokeBuiltin(
     catch( const std::exception& e )
     {
         throw RuntimeException(
-            node.sourceLocation(),
+            { node.sourceLocation() },
             "builtin has thrown an exception: " + std::string( e.what() ),
             m_frameStack.generateBacktrace( node.sourceLocation(), m_agentId ),
             Code::RuntimeException );

--- a/src/execute/NumericExecutionPass.cpp
+++ b/src/execute/NumericExecutionPass.cpp
@@ -46,6 +46,7 @@
 
 #include <libcasm-fe/Logger>
 #include <libcasm-fe/execute/RuntimeException>
+#include <libcasm-fe/execute/UpdateException>
 
 #include <libcasm-fe/execute/ExecutionVisitor>
 
@@ -72,6 +73,29 @@ void NumericExecutionPass::usage( libpass::PassUsage& pu )
 {
     pu.require< SpecificationMergerPass >();
     pu.scheduleAfter< FrameSizeDeterminationPass >();
+}
+
+static std::string updateInfoToString( const UpdateException::UpdateInfo& updateInfo )
+{
+    auto locationStr = updateInfo.function->identifier()->name();
+
+    if( not updateInfo.arguments.empty() )
+    {
+        locationStr += "(";
+        bool isFirst = true;
+        for( const auto& arg : updateInfo.arguments )
+        {
+            if( not isFirst )
+            {
+                locationStr += ", ";
+            }
+            locationStr += arg.name();
+            isFirst = false;
+        }
+        locationStr += ")";
+    }
+
+    return locationStr + " := " + updateInfo.value.name();
 }
 
 u1 NumericExecutionPass::run( libpass::PassResult& pr )
@@ -149,6 +173,18 @@ u1 NumericExecutionPass::run( libpass::PassResult& pr )
 
         log.info(
             "Finished execution after " + std::to_string( scheduler.numberOfSteps() ) + " steps" );
+    }
+    catch( const UpdateException& e )
+    {
+        log.error( e );
+        log.info( "Backtrace:\n" + libstdhl::String::join( e.backtrace(), "\n" ) );
+        for( const auto& update : e.updateInfos() )
+        {
+            log.info(
+                { update.producer->sourceLocation() },
+                "Produced update '" + updateInfoToString( update ) + "'" );
+        }
+        return false;
     }
     catch( const RuntimeException& e )
     {

--- a/src/execute/NumericExecutionPass.cpp
+++ b/src/execute/NumericExecutionPass.cpp
@@ -43,8 +43,9 @@
 //
 
 #include "NumericExecutionPass.h"
-#include <libcasm-fe/Exception>
+
 #include <libcasm-fe/Logger>
+#include <libcasm-fe/execute/RuntimeException>
 
 #include <libcasm-fe/execute/ExecutionVisitor>
 
@@ -54,6 +55,8 @@
 #include <libpass/PassRegistry>
 #include <libpass/PassResult>
 #include <libpass/PassUsage>
+
+#include <libstdhl/String>
 
 #include <mutex>
 
@@ -150,6 +153,7 @@ u1 NumericExecutionPass::run( libpass::PassResult& pr )
     catch( const RuntimeException& e )
     {
         log.error( e );
+        log.info( "Backtrace:\n" + libstdhl::String::join( e.backtrace(), "\n" ) );
         return false;
     }
 

--- a/src/execute/RuntimeException.cpp
+++ b/src/execute/RuntimeException.cpp
@@ -49,14 +49,6 @@ using namespace libcasm_fe;
 RuntimeException::RuntimeException(
     const std::vector< libstdhl::SourceLocation >& locations,
     const std::string& message,
-    Code errorCode )
-: RuntimeException( locations, message, {}, errorCode )
-{
-}
-
-RuntimeException::RuntimeException(
-    const std::vector< libstdhl::SourceLocation >& locations,
-    const std::string& message,
     const std::vector< std::string >& backtrace,
     Code errorCode )
 : Exception( locations, message, errorCode )

--- a/src/execute/RuntimeException.cpp
+++ b/src/execute/RuntimeException.cpp
@@ -42,54 +42,32 @@
 //  statement from your version.
 //
 
-#ifndef _LIBCASM_FE_EXCEPTION_H_
-#define _LIBCASM_FE_EXCEPTION_H_
+#include "RuntimeException.h"
 
-#include <libcasm-fe/CasmFE>
-#include <libcasm-fe/Codes>
+using namespace libcasm_fe;
 
-#include <libstdhl/Exception>
-#include <libstdhl/SourceLocation>
-
-#include <string>
-#include <vector>
-
-namespace libcasm_fe
+RuntimeException::RuntimeException(
+    const std::vector< libstdhl::SourceLocation >& locations,
+    const std::string& message,
+    Code errorCode )
+: RuntimeException( locations, message, {}, errorCode )
 {
-    class Exception : public libstdhl::Exception
-    {
-      public:
-        Exception( const std::string& message );
-
-        Exception( const std::string& message, Code errorCode );
-
-        Exception(
-            const std::vector< libstdhl::SourceLocation >& locations,
-            const std::string& message,
-            Code errorCode );
-
-        const std::vector< libstdhl::SourceLocation >& locations( void ) const noexcept;
-
-        Code errorCode( void ) const noexcept;
-
-      private:
-        const std::vector< libstdhl::SourceLocation > m_locations;
-        const Code m_errorCode;
-    };
-
-    class CompiletimeException : public Exception
-    {
-        using Exception::Exception;
-    };
-
-    class ConfigurationException : public Exception
-    {
-      public:
-        using Exception::Exception;
-    };
 }
 
-#endif  // _LIBCASM_FE_EXCEPTION_H_
+RuntimeException::RuntimeException(
+    const std::vector< libstdhl::SourceLocation >& locations,
+    const std::string& message,
+    const std::vector< std::string >& backtrace,
+    Code errorCode )
+: Exception( locations, message, errorCode )
+, m_backtrace( backtrace )
+{
+}
+
+const std::vector< std::string >& RuntimeException::backtrace( void ) const noexcept
+{
+    return m_backtrace;
+}
 
 //
 //  Local variables:

--- a/src/execute/RuntimeException.h
+++ b/src/execute/RuntimeException.h
@@ -58,11 +58,6 @@ namespace libcasm_fe
         RuntimeException(
             const std::vector< libstdhl::SourceLocation >& locations,
             const std::string& message,
-            Code errorCode );
-
-        RuntimeException(
-            const std::vector< libstdhl::SourceLocation >& locations,
-            const std::string& message,
             const std::vector< std::string >& backtrace,
             Code errorCode );
 

--- a/src/execute/RuntimeException.h
+++ b/src/execute/RuntimeException.h
@@ -42,54 +42,38 @@
 //  statement from your version.
 //
 
-#ifndef _LIBCASM_FE_EXCEPTION_H_
-#define _LIBCASM_FE_EXCEPTION_H_
+#ifndef _LIBCASM_FE_RUNTIME_EXCEPTION_H_
+#define _LIBCASM_FE_RUNTIME_EXCEPTION_H_
 
-#include <libcasm-fe/CasmFE>
-#include <libcasm-fe/Codes>
-
-#include <libstdhl/Exception>
-#include <libstdhl/SourceLocation>
+#include <libcasm-fe/Exception>
 
 #include <string>
 #include <vector>
 
 namespace libcasm_fe
 {
-    class Exception : public libstdhl::Exception
+    class RuntimeException : public libcasm_fe::Exception
     {
       public:
-        Exception( const std::string& message );
-
-        Exception( const std::string& message, Code errorCode );
-
-        Exception(
+        RuntimeException(
             const std::vector< libstdhl::SourceLocation >& locations,
             const std::string& message,
             Code errorCode );
 
-        const std::vector< libstdhl::SourceLocation >& locations( void ) const noexcept;
+        RuntimeException(
+            const std::vector< libstdhl::SourceLocation >& locations,
+            const std::string& message,
+            const std::vector< std::string >& backtrace,
+            Code errorCode );
 
-        Code errorCode( void ) const noexcept;
+        const std::vector< std::string >& backtrace( void ) const noexcept;
 
       private:
-        const std::vector< libstdhl::SourceLocation > m_locations;
-        const Code m_errorCode;
-    };
-
-    class CompiletimeException : public Exception
-    {
-        using Exception::Exception;
-    };
-
-    class ConfigurationException : public Exception
-    {
-      public:
-        using Exception::Exception;
+        const std::vector< std::string > m_backtrace;
     };
 }
 
-#endif  // _LIBCASM_FE_EXCEPTION_H_
+#endif  // _LIBCASM_FE_RUNTIME_EXCEPTION_H_
 
 //
 //  Local variables:

--- a/src/execute/UpdateException.cpp
+++ b/src/execute/UpdateException.cpp
@@ -1,0 +1,84 @@
+//
+//  Copyright (C) 2014-2020 CASM Organization <https://casm-lang.org>
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                Florian Hahn
+//                Ioan Molnar
+//                <https://github.com/casm-lang/libcasm-fe>
+//
+//  This file is part of libcasm-fe.
+//
+//  libcasm-fe is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libcasm-fe is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libcasm-fe. If not, see <http://www.gnu.org/licenses/>.
+//
+//  Additional permission under GNU GPL version 3 section 7
+//
+//  libcasm-fe is distributed under the terms of the GNU General Public License
+//  with the following clarification and special exception: Linking libcasm-fe
+//  statically or dynamically with other modules is making a combined work
+//  based on libcasm-fe. Thus, the terms and conditions of the GNU General
+//  Public License cover the whole combination. As a special exception,
+//  the copyright holders of libcasm-fe give you permission to link libcasm-fe
+//  with independent modules to produce an executable, regardless of the
+//  license terms of these independent modules, and to copy and distribute
+//  the resulting executable under terms of your choice, provided that you
+//  also meet, for each linked independent module, the terms and conditions
+//  of the license of that module. An independent module is a module which
+//  is not derived from or based on libcasm-fe. If you modify libcasm-fe, you
+//  may extend this exception to your version of the library, but you are
+//  not obliged to do so. If you do not wish to do so, delete this exception
+//  statement from your version.
+//
+
+#include "UpdateException.h"
+
+using namespace libcasm_fe;
+
+UpdateException::UpdateException(
+    const std::vector< libstdhl::SourceLocation >& locations,
+    const std::string& message,
+    const std::vector< UpdateInfo >& updateInfos,
+    Code errorCode )
+: RuntimeException( locations, message, errorCode )
+, m_updateInfos( updateInfos )
+{
+}
+
+UpdateException::UpdateException(
+    const std::vector< libstdhl::SourceLocation >& locations,
+    const std::string& message,
+    const std::vector< std::string >& backtrace,
+    const std::vector< UpdateInfo >& updateInfos,
+    Code errorCode )
+: RuntimeException( locations, message, backtrace, errorCode )
+, m_updateInfos( updateInfos )
+{
+}
+
+const std::vector< UpdateException::UpdateInfo >& UpdateException::updateInfos( void ) const
+    noexcept
+{
+    return m_updateInfos;
+}
+
+//
+//  Local variables:
+//  mode: c++
+//  indent-tabs-mode: nil
+//  c-basic-offset: 4
+//  tab-width: 4
+//  End:
+//  vim:noexpandtab:sw=4:ts=4:
+//

--- a/src/execute/UpdateException.cpp
+++ b/src/execute/UpdateException.cpp
@@ -49,16 +49,6 @@ using namespace libcasm_fe;
 UpdateException::UpdateException(
     const std::vector< libstdhl::SourceLocation >& locations,
     const std::string& message,
-    const std::vector< UpdateInfo >& updateInfos,
-    Code errorCode )
-: RuntimeException( locations, message, errorCode )
-, m_updateInfos( updateInfos )
-{
-}
-
-UpdateException::UpdateException(
-    const std::vector< libstdhl::SourceLocation >& locations,
-    const std::string& message,
     const std::vector< std::string >& backtrace,
     const std::vector< UpdateInfo >& updateInfos,
     Code errorCode )

--- a/src/execute/UpdateException.h
+++ b/src/execute/UpdateException.h
@@ -1,0 +1,98 @@
+//
+//  Copyright (C) 2014-2020 CASM Organization <https://casm-lang.org>
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                Florian Hahn
+//                Ioan Molnar
+//                <https://github.com/casm-lang/libcasm-fe>
+//
+//  This file is part of libcasm-fe.
+//
+//  libcasm-fe is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libcasm-fe is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libcasm-fe. If not, see <http://www.gnu.org/licenses/>.
+//
+//  Additional permission under GNU GPL version 3 section 7
+//
+//  libcasm-fe is distributed under the terms of the GNU General Public License
+//  with the following clarification and special exception: Linking libcasm-fe
+//  statically or dynamically with other modules is making a combined work
+//  based on libcasm-fe. Thus, the terms and conditions of the GNU General
+//  Public License cover the whole combination. As a special exception,
+//  the copyright holders of libcasm-fe give you permission to link libcasm-fe
+//  with independent modules to produce an executable, regardless of the
+//  license terms of these independent modules, and to copy and distribute
+//  the resulting executable under terms of your choice, provided that you
+//  also meet, for each linked independent module, the terms and conditions
+//  of the license of that module. An independent module is a module which
+//  is not derived from or based on libcasm-fe. If you modify libcasm-fe, you
+//  may extend this exception to your version of the library, but you are
+//  not obliged to do so. If you do not wish to do so, delete this exception
+//  statement from your version.
+//
+
+#ifndef _LIBCASM_FE_UPDATE_EXCEPTION_H_
+#define _LIBCASM_FE_UPDATE_EXCEPTION_H_
+
+#include <libcasm-fe/ast/Definition>
+#include <libcasm-fe/ast/Node>
+#include <libcasm-fe/execute/RuntimeException>
+
+#include <libcasm-ir/Constant>
+
+namespace libcasm_fe
+{
+    class UpdateException : public libcasm_fe::RuntimeException
+    {
+      public:
+        struct UpdateInfo
+        {
+            Ast::Node::Ptr producer;
+            Ast::FunctionDefinition::Ptr function;
+            std::vector< libcasm_ir::Constant > arguments;
+            libcasm_ir::Constant value;
+        };
+
+      public:
+        UpdateException(
+            const std::vector< libstdhl::SourceLocation >& locations,
+            const std::string& message,
+            const std::vector< UpdateInfo >& updateInfos,
+            Code errorCode );
+
+        UpdateException(
+            const std::vector< libstdhl::SourceLocation >& locations,
+            const std::string& message,
+            const std::vector< std::string >& backtrace,
+            const std::vector< UpdateInfo >& updateInfos,
+            Code errorCode );
+
+        const std::vector< UpdateInfo >& updateInfos( void ) const noexcept;
+
+      private:
+        const std::vector< UpdateInfo > m_updateInfos;
+    };
+}
+
+#endif  // _LIBCASM_FE_UPDATE_EXCEPTION_H_
+
+//
+//  Local variables:
+//  mode: c++
+//  indent-tabs-mode: nil
+//  c-basic-offset: 4
+//  tab-width: 4
+//  End:
+//  vim:noexpandtab:sw=4:ts=4:
+//

--- a/src/execute/UpdateException.h
+++ b/src/execute/UpdateException.h
@@ -68,12 +68,6 @@ namespace libcasm_fe
         UpdateException(
             const std::vector< libstdhl::SourceLocation >& locations,
             const std::string& message,
-            const std::vector< UpdateInfo >& updateInfos,
-            Code errorCode );
-
-        UpdateException(
-            const std::vector< libstdhl::SourceLocation >& locations,
-            const std::string& message,
             const std::vector< std::string >& backtrace,
             const std::vector< UpdateInfo >& updateInfos,
             Code errorCode );


### PR DESCRIPTION
Use the current execution location which caused the update conflict instead of the update producer locations as error location.

The update producer locations are now used to print additional information about the updates which triggered the conflict.

An example conflict looks like this:
```
error: Conflict while collection updates from agents. 
Update 'chopOwner(c2) := Juan' produced by agent Juan 
clashed with update 'chopOwner(c2) := Sina' produced by agent Sina 

info: Produced update 'chopOwner(c2) := Juan' [NumericExecutionPass, Default]
application/DiningPhilosophers.casm:57:5..57:39
chopOwner(rightChop(self)) := self
^--------------------------------^

info: Produced update 'chopOwner(c2) := Sina' [NumericExecutionPass, Default]
application/DiningPhilosophers.casm:57:5..57:39
chopOwner(rightChop(self)) := self
^--------------------------------^
```

Tests have been adjusted in https://github.com/casm-lang/libcasm-tc/pull/89